### PR TITLE
Feat/products create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .env
+.pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -1,9 +1,59 @@
 # alkemy-g6
 
+## api/v1/products/**
+
+### Get Products
+
+REQ:
+
+```sh
+curl localhost:8080/api/v1/products
+```
+
+RES:
+
+```sh
+{"data":
+    [
+        {"id":3,"product_code":"P003","description":"Product 3","height":15,"length":10,"width":8,"weight":1.5,"expiration_rate":0.15,"freezing_rate":0.25,"recommended_freezing_temp":-15,"product_type_id":3,"seller_id":103},
+        {"id":6,"product_code":"P006","description":"Product 6","height":13,"length":14,"width":5.5,"weight":1.1,"expiration_rate":0.09,"freezing_rate":0.18,"recommended_freezing_temp":-19,"product_type_id":1,"seller_id":106},
+        {"id":12,"product_code":"P012","description":"Product 12","height":19,"length":25,"width":10,"weight":2.6,"expiration_rate":0.18,"freezing_rate":0.27,"recommended_freezing_temp":-18,"product_type_id":1,"seller_id":112},
+        {"id":16,"product_code":"P016","description":"Product 16","height":25,"length":30,"width":12,"weight":3.5,"expiration_rate":0.13,"freezing_rate":0.26,"recommended_freezing_temp":-22,"product_type_id":3,"seller_id":116},
+    ]
+}
+```
+
+### Get Product by ID
+
+REQ:
+
+```sh
+curl localhost:8080/api/v1/products/3
+```
+
+RES:
+
+```sh
+{"data":
+    {"id":3,"product_code":"P003","description":"Product 3","height":15,"length":10,"width":8,"weight":1.5,"expiration_rate":0.15,"freezing_rate":0.25,"recommended_freezing_temp":-15,"product_type_id":3,"seller_id":103}
+}
+```
+
 ### Create Product
+
+REQ:
 
 ```sh
 curl -X POST localhost:8080/api/v1/products \
 -H "Content-Type=application/json" \
 -d '{"product_code": "P0026", "description": "Product 1", "height": 10.0, "length": 15.0, "width": 5.0, "weight": 1.0, "expiration_rate": 0.1, "freezing_rate": 0.3, "recommended_freezing_temp": -18.0, "product_type_id": 1, "seller_id": 101}'
+```
+
+RES:
+
+```sh
+{
+    "message":"Created",
+    "data":{"ID":26,"ProductCode":"P001","Description":"Product 1","Height":10,"Length":15,"Width":5,"Weight":1,"ExpirationRate":0.1,"FreezingRate":0.3,"RecomFreezTemp":-18,"ProductTypeID":1,"SellerID":0}
+}
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # alkemy-g6
+
+### Create Product
+
+```sh
+curl -X POST localhost:8080/api/v1/products \
+-H "Content-Type=application/json" \
+-d '{"product_code": "P0026", "description": "Product 1", "height": 10.0, "length": 15.0, "width": 5.0, "weight": 1.0, "expiration_rate": 0.1, "freezing_rate": 0.3, "recommended_freezing_temp": -18.0, "product_type_id": 1, "seller_id": 101}'
+```

--- a/internal/application/init_product.go
+++ b/internal/application/init_product.go
@@ -21,6 +21,7 @@ func buildApiV1ProductsRoutes(rt *chi.Mux) {
 	rt.Route("/api/v1/products", func(rt chi.Router) {
 		rt.Get("/", ct.GetAll)
 		rt.Get("/{id}", ct.GetById)
+		rt.Post("/", ct.Create)
 	})
 }
 

--- a/internal/controllers/products/create.go
+++ b/internal/controllers/products/create.go
@@ -14,7 +14,7 @@ func (p *ProductsDefault) Create(w http.ResponseWriter, r *http.Request) {
 
 	err := prodJson.validate()
 	if err != nil {
-		response.Error(w, http.StatusBadRequest, err.Error())
+		response.Error(w, http.StatusUnprocessableEntity, err.Error())
 		return
 	}
 
@@ -41,5 +41,5 @@ func (p *ProductsDefault) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res := ProductResJSON{Message: "Created", Data: newProd}
-	response.JSON(w, http.StatusOK, res)
+	response.JSON(w, http.StatusCreated, res)
 }

--- a/internal/controllers/products/create.go
+++ b/internal/controllers/products/create.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+
+	models "github.com/maxwelbm/alkemy-g6/internal/models/products"
+	"github.com/maxwelbm/alkemy-g6/pkg/response"
+)
+
+func (p *ProductsDefault) Create(w http.ResponseWriter, r *http.Request) {
+	var prodJson NewProductAttributesJSON
+	json.NewDecoder(r.Body).Decode(&prodJson)
+
+	err := prodJson.validate()
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	prodDTO := models.ProductDTO{
+		ProductCode:    *prodJson.ProductCode,
+		Description:    *prodJson.Description,
+		Height:         *prodJson.Height,
+		Length:         *prodJson.Length,
+		Width:          *prodJson.Width,
+		Weight:         *prodJson.Weight,
+		ExpirationRate: *prodJson.ExpirationRate,
+		FreezingRate:   *prodJson.FreezingRate,
+		RecomFreezTemp: *prodJson.RecomFreezTemp,
+		ProductTypeID:  *prodJson.ProductTypeID,
+	}
+	if prodJson.SellerID != nil {
+		prodDTO.SellerID = *prodJson.SellerID
+	}
+
+	newProd, err := p.sv.Create(prodDTO)
+	if err != nil {
+		response.Error(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+
+	res := ProductResJSON{Message: "Created", Data: newProd}
+	response.JSON(w, http.StatusOK, res)
+}

--- a/internal/controllers/products/create.go
+++ b/internal/controllers/products/create.go
@@ -2,9 +2,11 @@ package controller
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	models "github.com/maxwelbm/alkemy-g6/internal/models/products"
+	repository "github.com/maxwelbm/alkemy-g6/internal/repository/products"
 	"github.com/maxwelbm/alkemy-g6/pkg/response"
 )
 
@@ -35,6 +37,10 @@ func (p *ProductsDefault) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	newProd, err := p.sv.Create(prodDTO)
+	if errors.Is(err, repository.ErrProductUniqueness) {
+		response.Error(w, http.StatusConflict, err.Error())
+		return
+	}
 	if err != nil {
 		response.Error(w, http.StatusUnprocessableEntity, err.Error())
 		return

--- a/internal/controllers/products/products_default.go
+++ b/internal/controllers/products/products_default.go
@@ -1,6 +1,11 @@
 package controller
 
-import models "github.com/maxwelbm/alkemy-g6/internal/models/products"
+import (
+	"errors"
+	"fmt"
+
+	models "github.com/maxwelbm/alkemy-g6/internal/models/products"
+)
 
 type ProductsDefault struct {
 	sv models.ProductService
@@ -28,4 +33,96 @@ type ProductFullJSON struct {
 	RecomFreezTemp float64 `json:"recommended_freezing_temp"`
 	ProductTypeID  int     `json:"product_type_id"`
 	SellerID       int     `json:"seller_id"`
+}
+
+type NewProductAttributesJSON struct {
+	ProductCode    *string  `json:"product_code"`
+	Description    *string  `json:"description"`
+	Height         *float64 `json:"height"`
+	Length         *float64 `json:"length"`
+	Width          *float64 `json:"width"`
+	Weight         *float64 `json:"weight"`
+	ExpirationRate *float64 `json:"expiration_rate"`
+	FreezingRate   *float64 `json:"freezing_rate"`
+	RecomFreezTemp *float64 `json:"recommended_freezing_temp"`
+	ProductTypeID  *int     `json:"product_type_id"`
+	SellerID       *int     `json:"seller_id,omitempty"`
+}
+
+func (p *NewProductAttributesJSON) validate() (err error) {
+	var validationErrors []string
+	var nilPointerErrors []string
+
+	// Check for nil pointers and collect their errors
+	if p.ProductCode == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute ProductCode cannot be nil")
+	} else if *p.ProductCode == "" {
+		validationErrors = append(validationErrors, "error: attribute ProductCode cannot be empty")
+	}
+
+	if p.Description == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute Description cannot be nil")
+	} else if *p.Description == "" {
+		validationErrors = append(validationErrors, "error: attribute Description cannot be empty")
+	}
+
+	if p.Height == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute Height cannot be nil")
+	} else if *p.Height <= 0 {
+		validationErrors = append(validationErrors, "error: attribute Height cannot be negative")
+	}
+
+	if p.Length == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute Length cannot be nil")
+	} else if *p.Length <= 0 {
+		validationErrors = append(validationErrors, "error: attribute Length cannot be negative")
+	}
+
+	if p.Width == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute Width cannot be nil")
+	} else if *p.Width <= 0 {
+		validationErrors = append(validationErrors, "error: attribute Width cannot be negative")
+	}
+
+	if p.Weight == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute Weight cannot be nil")
+	} else if *p.Weight <= 0 {
+		validationErrors = append(validationErrors, "error: attribute Weight cannot be negative")
+	}
+
+	if p.ExpirationRate == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute ExpirationRate cannot be nil")
+	} else if *p.ExpirationRate < 0 {
+		validationErrors = append(validationErrors, "error: attribute ExpirationRate cannot be negative")
+	}
+
+	if p.FreezingRate == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute FreezingRate cannot be nil")
+	} else if *p.FreezingRate < 0 {
+		validationErrors = append(validationErrors, "error: attribute FreezingRate cannot be negative")
+	}
+
+	if p.RecomFreezTemp == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute RecomFreezTemp cannot be nil")
+	}
+
+	if p.ProductTypeID == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute ProductTypeID cannot be nil")
+	} else if *p.ProductTypeID <= 0 {
+		validationErrors = append(validationErrors, "error: attribute ProductTypeID must be positive")
+	}
+
+	if p.SellerID != nil && *p.SellerID < 0 {
+		validationErrors = append(validationErrors, "error: attribute SellerID must be non-negative")
+	}
+
+	// Combine all errors before returning
+	if len(nilPointerErrors) > 0 || len(validationErrors) > 0 {
+		var allErrors []string
+		allErrors = append(allErrors, nilPointerErrors...)
+		allErrors = append(allErrors, validationErrors...)
+
+		err = errors.New(fmt.Sprintf("validation errors: %v", allErrors))
+	}
+	return
 }

--- a/internal/models/products/product_repository.go
+++ b/internal/models/products/product_repository.go
@@ -3,4 +3,5 @@ package models
 type ProductRepository interface {
 	GetAll() (list []Product, err error)
 	GetById(id int) (prod Product, err error)
+	Create(prod ProductDTO) (newProd Product, err error)
 }

--- a/internal/models/products/product_service.go
+++ b/internal/models/products/product_service.go
@@ -3,4 +3,5 @@ package models
 type ProductService interface {
 	GetAll() (list []Product, err error)
 	GetById(id int) (prod Product, err error)
+	Create(prod ProductDTO) (newProd Product, err error)
 }

--- a/internal/models/products/products.go
+++ b/internal/models/products/products.go
@@ -26,3 +26,18 @@ type Product struct {
 	// SellerID is the unique identifier of the seller
 	SellerID int
 }
+
+type ProductDTO struct {
+	ID             int
+	ProductCode    string
+	Description    string
+	Height         float64
+	Length         float64
+	Width          float64
+	Weight         float64
+	ExpirationRate float64
+	FreezingRate   float64
+	RecomFreezTemp float64
+	ProductTypeID  int
+	SellerID       int
+}

--- a/internal/repository/products/create.go
+++ b/internal/repository/products/create.go
@@ -1,0 +1,27 @@
+package repository
+
+import (
+	models "github.com/maxwelbm/alkemy-g6/internal/models/products"
+)
+
+func (p *Products) Create(prod models.ProductDTO) (newProd models.Product, err error) {
+	nextId := p.lastId + 1
+
+	newProd = models.Product{
+		ID:             nextId,
+		ProductCode:    prod.ProductCode,
+		Description:    prod.Description,
+		Height:         prod.Height,
+		Length:         prod.Length,
+		Width:          prod.Width,
+		Weight:         prod.Weight,
+		ExpirationRate: prod.ExpirationRate,
+		FreezingRate:   prod.FreezingRate,
+		RecomFreezTemp: prod.RecomFreezTemp,
+		ProductTypeID:  prod.ProductTypeID,
+		SellerID:       prod.SellerID,
+	}
+
+	p.db[nextId] = newProd
+	return
+}

--- a/internal/repository/products/create.go
+++ b/internal/repository/products/create.go
@@ -23,5 +23,6 @@ func (p *Products) Create(prod models.ProductDTO) (newProd models.Product, err e
 	}
 
 	p.db[nextId] = newProd
+	p.lastId = nextId
 	return
 }

--- a/internal/repository/products/create.go
+++ b/internal/repository/products/create.go
@@ -22,6 +22,10 @@ func (p *Products) Create(prod models.ProductDTO) (newProd models.Product, err e
 		SellerID:       prod.SellerID,
 	}
 
+	if err = p.validateProduct(newProd); err != nil {
+		return
+	}
+
 	p.db[nextId] = newProd
 	p.lastId = nextId
 	return

--- a/internal/repository/products/products_default.go
+++ b/internal/repository/products/products_default.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"errors"
+	"fmt"
 
 	models "github.com/maxwelbm/alkemy-g6/internal/models/products"
 )
@@ -31,4 +32,24 @@ func NewProducts(db map[int]models.Product) *Products {
 	}
 
 	return &Products{db: defaultDb, lastId: lastId}
+}
+
+func (p *Products) validateProduct(prod models.Product) (err error) {
+	var validationErrors []string
+
+	// validate ProductCode uniqueness
+	for _, dbProd := range p.db {
+		if prod.ProductCode == dbProd.ProductCode {
+			validationErrors = append(validationErrors, "error: attribute ProductCode must be unique")
+		}
+	}
+
+	// joins all validation errors into a new error
+	if len(validationErrors) > 0 {
+		var allErrors []string
+		allErrors = append(allErrors, validationErrors...)
+
+		err = errors.New(fmt.Sprintf("validation errors: %v", allErrors))
+	}
+	return
 }

--- a/internal/repository/products/products_default.go
+++ b/internal/repository/products/products_default.go
@@ -11,13 +11,24 @@ var (
 )
 
 type Products struct {
-	db map[int]models.Product
+	db     map[int]models.Product
+	lastId int
 }
 
 func NewProducts(db map[int]models.Product) *Products {
+	// initializes db map
 	defaultDb := make(map[int]models.Product)
 	if db != nil {
 		defaultDb = db
 	}
-	return &Products{db: defaultDb}
+
+	// assigns last id
+	lastId := 0
+	for _, p := range db {
+		if lastId < p.ID {
+			lastId = p.ID
+		}
+	}
+
+	return &Products{db: defaultDb, lastId: lastId}
 }

--- a/internal/repository/products/products_default.go
+++ b/internal/repository/products/products_default.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	ErrProductNotFound = errors.New("Product not found")
+	ErrProductNotFound   = errors.New("Product not found")
+	ErrProductUniqueness = errors.New("Product attribute uniqueness")
 )
 
 type Products struct {
@@ -35,21 +36,11 @@ func NewProducts(db map[int]models.Product) *Products {
 }
 
 func (p *Products) validateProduct(prod models.Product) (err error) {
-	var validationErrors []string
-
 	// validate ProductCode uniqueness
 	for _, dbProd := range p.db {
 		if prod.ProductCode == dbProd.ProductCode {
-			validationErrors = append(validationErrors, "error: attribute ProductCode must be unique")
+			err = errors.Join(err, fmt.Errorf("%w: %s", ErrProductUniqueness, "Product Code"))
 		}
-	}
-
-	// joins all validation errors into a new error
-	if len(validationErrors) > 0 {
-		var allErrors []string
-		allErrors = append(allErrors, validationErrors...)
-
-		err = errors.New(fmt.Sprintf("validation errors: %v", allErrors))
 	}
 	return
 }

--- a/internal/service/product_default.go
+++ b/internal/service/product_default.go
@@ -22,3 +22,8 @@ func (s *ProductsDefault) GetById(id int) (prod models.Product, err error) {
 	prod, err = s.repo.GetById(id)
 	return
 }
+
+func (s *ProductsDefault) Create(prod models.ProductDTO) (newProd models.Product, err error) {
+	newProd, err = s.repo.Create(prod)
+	return
+}


### PR DESCRIPTION
## Motivação

Precisamos de um recurso que permita a criação de novos produtos com o parametro seller_id opcional e todos os outros obrigatórios

## Solução proposta

Adiciona nova rota de POST `/api/v1/products`
- Esta rota recebe um objeto json representando um produto com todos os seus atributos, exceto ID, que será gerado automaticamente
- Em caso de parametros obrigatórios faltando, a rota deve retornar um erro 422
- Em caso de sucesso, a rota deve retornar um status 201

## Como testar

teste a nova rota com um comando curl:

```sh
curl -X POST localhost:8080/api/v1/products \
-H "Content-Type=application/json" \
-d '{"product_code": "P0026", "description": "Product 1", "height": 10.0, "length": 15.0, "width": 5.0, "weight": 1.0, "expiration_rate": 0.1, "freezing_rate": 0.3, "recommended_freezing_temp": -18.0, "product_type_id": 1, "seller_id": 101}'
```

Também deve funcionar removendo o seller_id, e deve retornar um erro 422 caso outros atributos estejam ausentes
Caso o product_code usado já exista, deve retornar um erro 409
