### PR TITLE
Adiciona delete de produtos

### DIFF
--- a/internal/application/init_product.go
+++ b/internal/application/init_product.go
@@ -21,6 +21,7 @@ func buildApiV1ProductsRoutes(rt *chi.Mux) {
 	rt.Route("/api/v1/products", func(rt chi.Router) {
 		rt.Get("/", ct.GetAll)
 		rt.Get("/{id}", ct.GetById)
+		rt.Delete("/{id}", ct.Delete)
 	})
 }
 

--- a/internal/controllers/products/delete.go
+++ b/internal/controllers/products/delete.go
@@ -1,0 +1,32 @@
+package controller
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	repository "github.com/maxwelbm/alkemy-g6/internal/repository/products"
+	"github.com/maxwelbm/alkemy-g6/pkg/response"
+)
+
+func (p *ProductsDefault) Delete(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, "Invalid ID format")
+		return
+	}
+
+	err = p.sv.Delete(id)
+	if errors.Is(err, repository.ErrProductNotFound) {
+		response.Error(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if err != nil {
+		response.Error(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	res := ProductResJSON{Message: "No content"}
+	response.JSON(w, http.StatusNoContent, res)
+}

--- a/internal/models/products/product_repository.go
+++ b/internal/models/products/product_repository.go
@@ -3,4 +3,5 @@ package models
 type ProductRepository interface {
 	GetAll() (list []Product, err error)
 	GetById(id int) (prod Product, err error)
+	Delete(id int) (err error)
 }

--- a/internal/models/products/product_service.go
+++ b/internal/models/products/product_service.go
@@ -3,4 +3,5 @@ package models
 type ProductService interface {
 	GetAll() (list []Product, err error)
 	GetById(id int) (prod Product, err error)
+	Delete(id int) (err error)
 }

--- a/internal/repository/products/delete.go
+++ b/internal/repository/products/delete.go
@@ -1,0 +1,11 @@
+package repository
+
+func (p *Products) Delete(id int) (err error) {
+
+	_, ok := p.db[id]
+	if !ok {
+		err = ErrProductNotFound
+	}
+	delete(p.db, id)
+	return
+}

--- a/internal/service/product_default.go
+++ b/internal/service/product_default.go
@@ -22,3 +22,8 @@ func (s *ProductsDefault) GetById(id int) (prod models.Product, err error) {
 	prod, err = s.repo.GetById(id)
 	return
 }
+
+func (s *ProductsDefault) Delete(id int) (err error) {
+	err = s.repo.Delete(id)
+	return
+}


### PR DESCRIPTION
## Motivação

- Um usuário deve ser capaz de deletar um produto a partir de seu id

## Solução proposta

- Adiciona rota DELETE `/api/v1/produts/{id}` com implementação interna p/ deletar recurso

## Como testar

- Faça duas requisições delete no id 1 com `curl -X DELETE localhost:8080/api/v1/products/1`
A primeira requisição deve ter status 204 e a segunda 404 já que o produto foi deletado