### PR TITLE
Feat/create sections

### DIFF
--- a/internal/application/init_sections.go
+++ b/internal/application/init_sections.go
@@ -21,6 +21,7 @@ func buildApiV1SectionsRoutes(rt *chi.Mux) {
 	rt.Route("/api/v1/sections", func(rt chi.Router) {
 		rt.Get("/", ct.GetAll)
 		rt.Get("/{id}", ct.GetById)
+		rt.Post("/", ct.Create)
 	})
 }
 

--- a/internal/controllers/sections/create.go
+++ b/internal/controllers/sections/create.go
@@ -1,0 +1,50 @@
+package sections
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	models "github.com/maxwelbm/alkemy-g6/internal/models/sections"
+	repository "github.com/maxwelbm/alkemy-g6/internal/repository/sections"
+	"github.com/maxwelbm/alkemy-g6/pkg/response"
+)
+
+func (c *SectionsDefault) Create(w http.ResponseWriter, r *http.Request) {
+	var secReqJson NewSectionReqJSON
+	json.NewDecoder(r.Body).Decode(&secReqJson)
+
+	err := secReqJson.validate()
+	if err != nil {
+		response.Error(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+
+	secDTO := models.SectionDTO{
+		SectionNumber:      *secReqJson.SectionNumber,
+		CurrentTemperature: *secReqJson.CurrentTemperature,
+		MinimumTemperature: *secReqJson.MinimumTemperature,
+		CurrentCapacity:    *secReqJson.CurrentCapacity,
+		MinimumCapacity:    *secReqJson.MinimumCapacity,
+		MaximumCapacity:    *secReqJson.MaximumCapacity,
+		WarehouseID:        *secReqJson.WarehouseID,
+		ProductTypeID:      *secReqJson.ProductTypeID,
+	}
+
+	newSection, err := c.sv.Create(secDTO)
+	if errors.Is(err, repository.ErrSectionDuplicatedCode) {
+		response.Error(w, http.StatusConflict, err.Error())
+		return
+	}
+	if err != nil {
+		response.Error(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+
+	res := SectionResJSON{
+		Message: "Created",
+		Data:    newSection,
+	}
+	response.JSON(w, http.StatusCreated, res)
+	return
+}

--- a/internal/controllers/sections/sections_default.go
+++ b/internal/controllers/sections/sections_default.go
@@ -1,6 +1,11 @@
 package sections
 
-import models "github.com/maxwelbm/alkemy-g6/internal/models/sections"
+import (
+	"errors"
+	"fmt"
+
+	models "github.com/maxwelbm/alkemy-g6/internal/models/sections"
+)
 
 type SectionsDefault struct {
 	// sv is the service used by the handler
@@ -19,6 +24,17 @@ type SectionFullJSON struct {
 	ProductTypeID      int     `json:"product_type_id"`
 }
 
+type NewSectionReqJSON struct {
+	SectionNumber      *int     `json:"section_number"`
+	CurrentTemperature *float64 `json:"current_temperature"`
+	MinimumTemperature *float64 `json:"minimum_temperature"`
+	CurrentCapacity    *int     `json:"current_capacity"`
+	MinimumCapacity    *int     `json:"minimum_capacity"`
+	MaximumCapacity    *int     `json:"maximum_capacity"`
+	WarehouseID        *int     `json:"warehouse_id"`
+	ProductTypeID      *int     `json:"product_type_id"`
+}
+
 type SectionResJSON struct {
 	Message string `json:"message,omitempty"`
 	Data    any    `json:"data,omitempty"`
@@ -28,4 +44,64 @@ func NewSectionsDefault(sv models.SectionService) *SectionsDefault {
 	return &SectionsDefault{
 		sv: sv,
 	}
+}
+
+func (c *NewSectionReqJSON) validate() (err error) {
+	var validationErrors []string
+	var nilPointerErrors []string
+
+	// Check for nil pointers and collect their errors
+	if c.SectionNumber == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute SectionNumber cannot be nil")
+	} else if *c.SectionNumber <= 0 {
+		validationErrors = append(validationErrors, "error: attribute SectionNumber cannot be empty")
+	}
+
+	if c.CurrentTemperature == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute CurrentTemperature cannot be nil")
+	}
+
+	if c.MinimumTemperature == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute MinimumTemperature cannot be nil")
+	}
+
+	if c.CurrentCapacity == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute CurrentCapacity cannot be nil")
+	} else if *c.CurrentCapacity <= 0 {
+		validationErrors = append(validationErrors, "error: attribute CurrentCapacity cannot be negative")
+	}
+
+	if c.MinimumCapacity == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute MinimumCapacity cannot be nil")
+	} else if *c.MinimumCapacity <= 0 {
+		validationErrors = append(validationErrors, "error: attribute MinimumCapacity cannot be negative")
+	}
+
+	if c.MaximumCapacity == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute MaximumCapacity cannot be nil")
+	} else if *c.MaximumCapacity <= 0 {
+		validationErrors = append(validationErrors, "error: attribute MaximumCapacity cannot be negative")
+	}
+
+	if c.WarehouseID == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute WarehouseID cannot be nil")
+	} else if *c.WarehouseID <= 0 {
+		validationErrors = append(validationErrors, "error: attribute WarehouseID must be positive")
+	}
+
+	if c.ProductTypeID == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute ProductTypeID cannot be nil")
+	} else if *c.ProductTypeID <= 0 {
+		validationErrors = append(validationErrors, "error: attribute ProductTypeID must be positive")
+	}
+
+	// Combine all errors before returning
+	if len(nilPointerErrors) > 0 || len(validationErrors) > 0 {
+		var allErrors []string
+		allErrors = append(allErrors, nilPointerErrors...)
+		allErrors = append(allErrors, validationErrors...)
+
+		err = errors.New(fmt.Sprintf("validation errors: %v", allErrors))
+	}
+	return
 }

--- a/internal/controllers/sections/sections_default.go
+++ b/internal/controllers/sections/sections_default.go
@@ -67,13 +67,13 @@ func (c *NewSectionReqJSON) validate() (err error) {
 
 	if c.CurrentCapacity == nil {
 		nilPointerErrors = append(nilPointerErrors, "error: attribute CurrentCapacity cannot be nil")
-	} else if *c.CurrentCapacity <= 0 {
+	} else if *c.CurrentCapacity < 0 {
 		validationErrors = append(validationErrors, "error: attribute CurrentCapacity cannot be negative")
 	}
 
 	if c.MinimumCapacity == nil {
 		nilPointerErrors = append(nilPointerErrors, "error: attribute MinimumCapacity cannot be nil")
-	} else if *c.MinimumCapacity <= 0 {
+	} else if *c.MinimumCapacity < 0 {
 		validationErrors = append(validationErrors, "error: attribute MinimumCapacity cannot be negative")
 	}
 

--- a/internal/models/sections/section_repository.go
+++ b/internal/models/sections/section_repository.go
@@ -3,4 +3,5 @@ package models
 type SectionRepository interface {
 	GetAll() (sections []Section, err error)
 	GetById(id int) (section Section, err error)
+	Create(sec SectionDTO) (newSection Section, err error)
 }

--- a/internal/models/sections/section_service.go
+++ b/internal/models/sections/section_service.go
@@ -3,4 +3,5 @@ package models
 type SectionService interface {
 	GetAll() (sections []Section, err error)
 	GetById(id int) (section Section, err error)
+	Create(sec SectionDTO) (newSection Section, err error)
 }

--- a/internal/models/sections/sections.go
+++ b/internal/models/sections/sections.go
@@ -11,3 +11,15 @@ type Section struct {
 	WarehouseID        int
 	ProductTypeID      int
 }
+
+type SectionDTO struct {
+	ID                 int
+	SectionNumber      int
+	CurrentTemperature float64
+	MinimumTemperature float64
+	CurrentCapacity    int
+	MinimumCapacity    int
+	MaximumCapacity    int
+	WarehouseID        int
+	ProductTypeID      int
+}

--- a/internal/repository/sections/create.go
+++ b/internal/repository/sections/create.go
@@ -1,0 +1,29 @@
+package repository
+
+import models "github.com/maxwelbm/alkemy-g6/internal/models/sections"
+
+func (r *Sections) Create(sec models.SectionDTO) (newSection models.Section, err error) {
+	for _, section := range r.db {
+		if section.SectionNumber == sec.SectionNumber {
+			err = ErrSectionDuplicatedCode
+			return
+		}
+	}
+
+	newSection = models.Section{
+		ID:                 r.lastId + 1,
+		SectionNumber:      sec.SectionNumber,
+		CurrentTemperature: sec.CurrentTemperature,
+		MinimumTemperature: sec.MinimumTemperature,
+		CurrentCapacity:    sec.CurrentCapacity,
+		MinimumCapacity:    sec.MinimumCapacity,
+		MaximumCapacity:    sec.MaximumCapacity,
+		WarehouseID:        sec.WarehouseID,
+		ProductTypeID:      sec.ProductTypeID,
+	}
+
+	r.db[newSection.ID] = newSection
+	r.lastId = newSection.ID
+
+	return
+}

--- a/internal/repository/sections/sections_default.go
+++ b/internal/repository/sections/sections_default.go
@@ -7,11 +7,13 @@ import (
 )
 
 var (
-	ErrSectionNotFound = errors.New("Section not found")
+	ErrSectionNotFound       = errors.New("Section not found")
+	ErrSectionDuplicatedCode = errors.New("Section code already exists")
 )
 
 type Sections struct {
-	db map[int]models.Section
+	db     map[int]models.Section
+	lastId int
 }
 
 func NewSections(db map[int]models.Section) *Sections {
@@ -19,5 +21,16 @@ func NewSections(db map[int]models.Section) *Sections {
 	if db != nil {
 		defaultDb = db
 	}
-	return &Sections{db: defaultDb}
+
+	lastId := 0
+	for _, sec := range db {
+		if lastId < sec.ID {
+			lastId = sec.ID
+		}
+	}
+
+	return &Sections{
+		db:     defaultDb,
+		lastId: lastId,
+	}
 }

--- a/internal/service/section_default.go
+++ b/internal/service/section_default.go
@@ -24,3 +24,8 @@ func (s *SectionsDefault) GetById(id int) (section models.Section, err error) {
 	section, err = s.repo.GetById(id)
 	return
 }
+
+func (s *SectionsDefault) Create(sec models.SectionDTO) (newSection models.Section, err error) {
+	newSection, err = s.repo.Create(sec)
+	return
+}


### PR DESCRIPTION
Objetivo: 
Adicionar endpoint de criação de seção em /api/v1/sections referente ao requisito 3

Solução Proposta:
Controller: com o endpoint definido para criar a seção com validação dos atributos passados na requisição
Service: com o método Create
Repository: com a lógica para criar uma nova seção, atualizando o lastID e validação de section number único

Retornamos 201 (Created) quando todos os atributos passados são válidos e o section number é único
Retornamos 409 (Conflict) se o section number já existir
Retornamos 422 (Unprocessable Entity) se o objeto JSON não contiver os campos obrigatórios ou válidos