### PR TITLE
Adicona Update p/ products

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ RES:
 }
 ```
 
+### Update Product
+
+REQ:
+
+```sh
+curl -X PATCH localhost:8080/api/v1/products/1 \
+-H "Content-Type=application/json" \
+-d '{"product_code": "P026", "description": "Product 26"}'
+```
+
+RES:
+
+```sh
+{
+    "message":"Updated",
+    "data":{"data":{"ID":1,"ProductCode":"P026","Description":"Product 1","Height":10,"Length":15,"Width":5,"Weight":1,"ExpirationRate":0.1,"FreezingRate":0.3,"RecomFreezTemp":-18,"ProductTypeID":1,"SellerID":101}}
+}
+```
+
 ### Delete Product
 
 REQ:

--- a/internal/application/init_product.go
+++ b/internal/application/init_product.go
@@ -22,6 +22,7 @@ func buildApiV1ProductsRoutes(rt *chi.Mux) {
 		rt.Get("/", ct.GetAll)
 		rt.Get("/{id}", ct.GetById)
 		rt.Post("/", ct.Create)
+		rt.Patch("/{id}", ct.Update)
 		rt.Delete("/{id}", ct.Delete)
 	})
 }

--- a/internal/controllers/products/products_default.go
+++ b/internal/controllers/products/products_default.go
@@ -126,3 +126,17 @@ func (p *NewProductAttributesJSON) validate() (err error) {
 	}
 	return
 }
+
+type UpdateProductAttributesJSON struct {
+	ProductCode    string  `json:"product_code,omitempty"`
+	Description    string  `json:"description,omitempty"`
+	Height         float64 `json:"height,omitempty"`
+	Length         float64 `json:"length,omitempty"`
+	Width          float64 `json:"width,omitempty"`
+	Weight         float64 `json:"weight,omitempty"`
+	ExpirationRate float64 `json:"expiration_rate,omitempty"`
+	FreezingRate   float64 `json:"freezing_rate,omitempty"`
+	RecomFreezTemp float64 `json:"recommended_freezing_temp,omitempty"`
+	ProductTypeID  int     `json:"product_type_id,omitempty"`
+	SellerID       int     `json:"seller_id,omitempty"`
+}

--- a/internal/controllers/products/update.go
+++ b/internal/controllers/products/update.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	models "github.com/maxwelbm/alkemy-g6/internal/models/products"
+	repository "github.com/maxwelbm/alkemy-g6/internal/repository/products"
+	"github.com/maxwelbm/alkemy-g6/pkg/response"
+)
+
+func (p *ProductsDefault) Update(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, "Invalid ID format")
+		return
+	}
+
+	var prodJson UpdateProductAttributesJSON
+	json.NewDecoder(r.Body).Decode(&prodJson)
+
+	prodDTO := models.ProductDTO{
+		ProductCode:    prodJson.ProductCode,
+		Description:    prodJson.Description,
+		Height:         prodJson.Height,
+		Length:         prodJson.Length,
+		Width:          prodJson.Width,
+		Weight:         prodJson.Weight,
+		ExpirationRate: prodJson.ExpirationRate,
+		FreezingRate:   prodJson.FreezingRate,
+		RecomFreezTemp: prodJson.RecomFreezTemp,
+		ProductTypeID:  prodJson.ProductTypeID,
+		SellerID:       prodJson.SellerID,
+	}
+
+	updatedProd, err := p.sv.Update(id, prodDTO)
+	if errors.Is(err, repository.ErrProductNotFound) {
+		response.Error(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if errors.Is(err, repository.ErrProductUniqueness) {
+		response.Error(w, http.StatusConflict, err.Error())
+		return
+	}
+	if err != nil {
+		response.Error(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+
+	res := ProductResJSON{Message: "Updated", Data: updatedProd}
+	response.JSON(w, http.StatusOK, res)
+}

--- a/internal/models/products/product_repository.go
+++ b/internal/models/products/product_repository.go
@@ -4,5 +4,6 @@ type ProductRepository interface {
 	GetAll() (list []Product, err error)
 	GetById(id int) (prod Product, err error)
 	Create(prod ProductDTO) (newProd Product, err error)
+	Update(id int, prod ProductDTO) (updatedProd Product, err error)
 	Delete(id int) (err error)
 }

--- a/internal/models/products/product_service.go
+++ b/internal/models/products/product_service.go
@@ -3,6 +3,7 @@ package models
 type ProductService interface {
 	GetAll() (list []Product, err error)
 	GetById(id int) (prod Product, err error)
-	Delete(id int) (err error)
 	Create(prod ProductDTO) (newProd Product, err error)
+	Update(id int, prod ProductDTO) (updatedProd Product, err error)
+	Delete(id int) (err error)
 }

--- a/internal/repository/products/products_default.go
+++ b/internal/repository/products/products_default.go
@@ -36,8 +36,14 @@ func NewProducts(db map[int]models.Product) *Products {
 }
 
 func (p *Products) validateProduct(prod models.Product) (err error) {
-	// validate ProductCode uniqueness
+	// Uniqueness
 	for _, dbProd := range p.db {
+		// skips self
+		if prod.ID == dbProd.ID {
+			continue
+		}
+
+		// validate ProductCode uniqueness
 		if prod.ProductCode == dbProd.ProductCode {
 			err = errors.Join(err, fmt.Errorf("%w: %s", ErrProductUniqueness, "Product Code"))
 		}

--- a/internal/repository/products/update.go
+++ b/internal/repository/products/update.go
@@ -1,0 +1,56 @@
+package repository
+
+import models "github.com/maxwelbm/alkemy-g6/internal/models/products"
+
+func (p *Products) Update(id int, prod models.ProductDTO) (updatedProd models.Product, err error) {
+	updatedProd, ok := p.db[id]
+	// Checks if product is present
+	if !ok {
+		err = ErrProductNotFound
+		return
+	}
+
+	// Updates attributes that are present
+	if prod.ProductCode != "" {
+		updatedProd.ProductCode = prod.ProductCode
+	}
+	if prod.Description != "" {
+		updatedProd.Description = prod.Description
+	}
+	if prod.Height != 0 {
+		updatedProd.Height = prod.Height
+	}
+	if prod.Length != 0 {
+		updatedProd.Length = prod.Length
+	}
+	if prod.Width != 0 {
+		updatedProd.Width = prod.Width
+	}
+	if prod.Weight != 0 {
+		updatedProd.Weight = prod.Weight
+	}
+	if prod.ExpirationRate != 0 {
+		updatedProd.ExpirationRate = prod.ExpirationRate
+	}
+	if prod.FreezingRate != 0 {
+		updatedProd.FreezingRate = prod.FreezingRate
+	}
+	if prod.RecomFreezTemp != 0 {
+		updatedProd.RecomFreezTemp = prod.RecomFreezTemp
+	}
+	if prod.ProductTypeID != 0 {
+		updatedProd.ProductTypeID = prod.ProductTypeID
+	}
+	if prod.SellerID != 0 {
+		updatedProd.SellerID = prod.SellerID
+	}
+
+	// Validate all attributes at once
+	if err = p.validateProduct(updatedProd); err != nil {
+		return
+	}
+
+	// updated record in the database
+	p.db[id] = updatedProd
+	return
+}

--- a/internal/service/product_default.go
+++ b/internal/service/product_default.go
@@ -28,6 +28,11 @@ func (s *ProductsDefault) Create(prod models.ProductDTO) (newProd models.Product
 	return
 }
 
+func (s *ProductsDefault) Update(id int, prod models.ProductDTO) (updatedProd models.Product, err error) {
+	updatedProd, err = s.repo.Update(id, prod)
+	return
+}
+
 func (s *ProductsDefault) Delete(id int) (err error) {
 	err = s.repo.Delete(id)
 	return


### PR DESCRIPTION
## Motivação

- Um usuário deve poder atualizar os dados de um produto já existente

## Solução proposta

- Adiciona rota PATCH `/api/v1/products/:id`
- Adiciona lógica que recebe atributos de produtos em requisição http e atualiza o registro de um produto

## Como testar

- Faça uma requisição Patch conforme descrito no README
- Caso o produto já exista, a requsição deve retornar um status 200 atualizando os dados
- Caso o produto não exista, deve retornar um erro 404
- Caso o código do produto já esteja cadastrado no banco, deve retornar um status 409