### PR TITLE
Feat/delete sections

### DIFF
--- a/internal/application/init_sections.go
+++ b/internal/application/init_sections.go
@@ -22,6 +22,7 @@ func buildApiV1SectionsRoutes(rt *chi.Mux) {
 		rt.Get("/", ct.GetAll)
 		rt.Get("/{id}", ct.GetById)
 		rt.Post("/", ct.Create)
+		rt.Delete("/{id}", ct.Delete)
 	})
 }
 

--- a/internal/controllers/sections/delete.go
+++ b/internal/controllers/sections/delete.go
@@ -1,7 +1,29 @@
 package sections
 
-import "net/http"
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/maxwelbm/alkemy-g6/pkg/response"
+)
 
 func (c *SectionsDefault) Delete(w http.ResponseWriter, r *http.Request) {
-	return
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, "Invalid Id format ")
+		return
+	}
+
+	err = c.sv.Delete(id)
+
+	if err != nil {
+		response.JSON(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	res := SectionResJSON{
+		Message: "No content",
+	}
+	response.JSON(w, http.StatusNoContent, res)
 }

--- a/internal/controllers/sections/delete.go
+++ b/internal/controllers/sections/delete.go
@@ -1,0 +1,7 @@
+package sections
+
+import "net/http"
+
+func (c *SectionsDefault) Delete(w http.ResponseWriter, r *http.Request) {
+	return
+}

--- a/internal/models/sections/section_repository.go
+++ b/internal/models/sections/section_repository.go
@@ -4,4 +4,5 @@ type SectionRepository interface {
 	GetAll() (sections []Section, err error)
 	GetById(id int) (section Section, err error)
 	Create(sec SectionDTO) (newSection Section, err error)
+	Delete(id int) (err error)
 }

--- a/internal/models/sections/section_service.go
+++ b/internal/models/sections/section_service.go
@@ -4,4 +4,5 @@ type SectionService interface {
 	GetAll() (sections []Section, err error)
 	GetById(id int) (section Section, err error)
 	Create(sec SectionDTO) (newSection Section, err error)
+	Delete(id int) (err error)
 }

--- a/internal/models/sections/sections.go
+++ b/internal/models/sections/sections.go
@@ -13,7 +13,6 @@ type Section struct {
 }
 
 type SectionDTO struct {
-	ID                 int
 	SectionNumber      int
 	CurrentTemperature float64
 	MinimumTemperature float64

--- a/internal/repository/sections/delete.go
+++ b/internal/repository/sections/delete.go
@@ -1,6 +1,14 @@
 package repository
 
 func (r *Sections) Delete(id int) (err error) {
+	_, ok := r.db[id]
+
+	if !ok {
+		err = ErrSectionNotFound
+		return
+	}
+
+	delete(r.db, id)
 
 	return
 }

--- a/internal/repository/sections/delete.go
+++ b/internal/repository/sections/delete.go
@@ -1,0 +1,6 @@
+package repository
+
+func (r *Sections) Delete(id int) (err error) {
+
+	return
+}

--- a/internal/service/section_default.go
+++ b/internal/service/section_default.go
@@ -29,3 +29,8 @@ func (s *SectionsDefault) Create(sec models.SectionDTO) (newSection models.Secti
 	newSection, err = s.repo.Create(sec)
 	return
 }
+
+func (s *SectionsDefault) Delete(id int) (err error) {
+	err = s.repo.Delete(id)
+	return
+}


### PR DESCRIPTION
Objetivo: 
Adicionar endpoint de deleção de seção em /api/v1/sections/:id referente ao requisito 3

Solução Proposta:
Controller: com o endpoint definido para deletar uma seção
Service: com o método Delete
Repository: com a lógica para deletar uma seção

Retornamos 204 (No content) quando a exclusão for bem-sucedida.
Retornamos 404 (Not Found) quando a seção não existir.