### PR TITLE
Feat/post buyers

### DIFF
--- a/internal/application/init_buyer.go
+++ b/internal/application/init_buyer.go
@@ -21,6 +21,7 @@ func buildApiV1BuyerRoutes(rt *chi.Mux) {
 	rt.Route("/api/v1/buyers", func(rt chi.Router) {
 		rt.Get("/", ct.GetAll)
 		rt.Get("/{id}", ct.GetById)
+		rt.Post("/", ct.PostBuyer)
 	})
 }
 

--- a/internal/controllers/buyer/buyer_default.go
+++ b/internal/controllers/buyer/buyer_default.go
@@ -27,6 +27,13 @@ type BuyerDataResJSON struct {
 	LastName     string `json:"last_name"`
 }
 
+type BuyerRequestPost struct {
+	Id           *int    `json:"id,omitempty"`
+	CardNumberId *string `json:"card_number_id,omitempty"`
+	FirstName    *string `json:"first_name,omitempty"`
+	LastName     *string `json:"last_name,omitempty"`
+}
+
 type BuyerDefault struct {
 	sv modelsBuyer.BuyerService
 }

--- a/internal/controllers/buyer/post.go
+++ b/internal/controllers/buyer/post.go
@@ -1,0 +1,58 @@
+package buyerController
+
+import (
+	"encoding/json"
+	"net/http"
+
+	modelsBuyer "github.com/maxwelbm/alkemy-g6/internal/models/buyer"
+	"github.com/maxwelbm/alkemy-g6/pkg/response"
+)
+
+func (controller *BuyerDefault) PostBuyer(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+
+	var buyerRequest BuyerRequestPost
+	if err := json.NewDecoder(r.Body).Decode(&buyerRequest); err != nil {
+		response.JSON(w, http.StatusBadRequest, "Error ao decodificarJSON")
+		return
+	}
+
+	if buyerRequest.CardNumberId == nil {
+		response.JSON(w, http.StatusUnprocessableEntity, "CardNumberId inexists in requests!")
+		return
+	}
+
+	_, errCardNumberId := controller.sv.GetByCardNumberId(*buyerRequest.CardNumberId)
+
+	if errCardNumberId == nil {
+		response.Error(w, http.StatusConflict, "Card Number Id already exists!")
+		return
+	}
+
+	buyerToCreate := modelsBuyer.Buyer{
+		CardNumberId: *buyerRequest.CardNumberId,
+		FirstName:    *buyerRequest.FirstName,
+		LastName:     *buyerRequest.LastName,
+	}
+
+	buyerCreated, errToPost := controller.sv.PostBuyer(buyerToCreate)
+
+	if errToPost != nil {
+		response.Error(w, http.StatusInternalServerError, "Failed to done the post")
+		return
+	}
+
+	data := BuyerDataResJSON{
+		Id:           buyerCreated.Id,
+		CardNumberId: buyerCreated.CardNumberId,
+		FirstName:    buyerCreated.FirstName,
+		LastName:     buyerCreated.LastName,
+	}
+
+	res := BuyerResJSON{
+		Message: "Success",
+		Data:    data,
+	}
+	response.JSON(w, http.StatusCreated, res)
+
+}

--- a/internal/models/buyer/buyer_repository.go
+++ b/internal/models/buyer/buyer_repository.go
@@ -3,4 +3,6 @@ package modelsBuyer
 type BuyerRepository interface {
 	GetAll() (buyers []Buyer, err error)
 	GetById(id int) (buyer Buyer, err error)
+	GetByCardNumberId(cardNumberId string) (buyer Buyer, err error)
+	PostBuyer(buyer Buyer) (buyerReturn Buyer, err error)
 }

--- a/internal/models/buyer/buyer_service.go
+++ b/internal/models/buyer/buyer_service.go
@@ -3,4 +3,6 @@ package modelsBuyer
 type BuyerService interface {
 	GetAll() (buyers []Buyer, err error)
 	GetById(id int) (buyer Buyer, err error)
+	GetByCardNumberId(cardNumberId string) (buyer Buyer, err error)
+	PostBuyer(buyer Buyer) (buyerReturn Buyer, err error)
 }

--- a/internal/repository/buyer/get_by_card_number_id.go
+++ b/internal/repository/buyer/get_by_card_number_id.go
@@ -1,0 +1,23 @@
+package buyerRepository
+
+import (
+	"errors"
+	"fmt"
+
+	modelsBuyer "github.com/maxwelbm/alkemy-g6/internal/models/buyer"
+)
+
+func (r *BuyerRepository) GetByCardNumberId(cardNumberId string) (buyer modelsBuyer.Buyer, err error) {
+	for _, value := range r.Buyers {
+		if value.CardNumberId == cardNumberId {
+			valueConverted := modelsBuyer.Buyer{
+				Id:           value.Id,
+				CardNumberId: value.CardNumberId,
+				FirstName:    value.FirstName,
+				LastName:     value.LastName,
+			}
+			return valueConverted, nil
+		}
+	}
+	return modelsBuyer.Buyer{}, errors.New(fmt.Sprintf("Card Number Id %s not found in the base!", cardNumberId))
+}

--- a/internal/repository/buyer/post.go
+++ b/internal/repository/buyer/post.go
@@ -1,0 +1,10 @@
+package buyerRepository
+
+import modelsBuyer "github.com/maxwelbm/alkemy-g6/internal/models/buyer"
+
+func (r *BuyerRepository) PostBuyer(buyer modelsBuyer.Buyer) (buyerReturn modelsBuyer.Buyer, err error) {
+	buyer.Id = len(r.Buyers) + 1
+	r.NextID++
+	r.Buyers[buyer.Id] = buyer
+	return buyer, nil
+}

--- a/internal/service/buyer_default.go
+++ b/internal/service/buyer_default.go
@@ -21,3 +21,11 @@ func (s *BuyerDefault) GetAll() ([]modelsBuyer.Buyer, error) {
 func (s *BuyerDefault) GetById(id int) (modelsBuyer.Buyer, error) {
 	return s.rp.GetById(id)
 }
+
+func (s *BuyerDefault) GetByCardNumberId(cardNumberId string) (modelsBuyer.Buyer, error) {
+	return s.rp.GetByCardNumberId(cardNumberId)
+}
+
+func (s *BuyerDefault) PostBuyer(buyer modelsBuyer.Buyer) (modelsBuyer.Buyer, error) {
+	return s.rp.PostBuyer(buyer)
+}


### PR DESCRIPTION
Objetivo:
Adicionar endpoint para post de buyer em /api/v1/buyers/ referente ao requisito 6

Solução Proposta:
Controller: com o endpoint definido para post de buyer
Service: com o método Post
Repository: com a lógica para criação de um buyer

Retornamos 201 (Created) quando o buyer for criado.
Retornamos 422 (Status Unprocessable Entity) quando o JSON não contiver os campos obrigatórios.