### PR TITLE
Feat/patch buyers

### DIFF
--- a/internal/application/init_buyer.go
+++ b/internal/application/init_buyer.go
@@ -22,6 +22,7 @@ func buildApiV1BuyerRoutes(rt *chi.Mux) {
 		rt.Get("/", ct.GetAll)
 		rt.Get("/{id}", ct.GetById)
 		rt.Post("/", ct.PostBuyer)
+		rt.Patch("/{id}", ct.PatchBuyer)
 	})
 }
 

--- a/internal/controllers/buyer/buyer_default.go
+++ b/internal/controllers/buyer/buyer_default.go
@@ -34,6 +34,13 @@ type BuyerRequestPost struct {
 	LastName     *string `json:"last_name,omitempty"`
 }
 
+type BuyerRequestPatch struct {
+	Id           *int    `json:"id,omitempty"`
+	CardNumberId *string `json:"card_number_id,omitempty"`
+	FirstName    *string `json:"first_name,omitempty"`
+	LastName     *string `json:"last_name,omitempty"`
+}
+
 type BuyerDefault struct {
 	sv modelsBuyer.BuyerService
 }

--- a/internal/controllers/buyer/patch.go
+++ b/internal/controllers/buyer/patch.go
@@ -1,0 +1,75 @@
+package buyerController
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	modelsBuyer "github.com/maxwelbm/alkemy-g6/internal/models/buyer"
+	"github.com/maxwelbm/alkemy-g6/pkg/response"
+)
+
+func (controller *BuyerDefault) PatchBuyer(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil || id < 1 {
+		response.Error(w, http.StatusBadRequest, "Failed to convert request id")
+		return
+	}
+
+	buyer, err := controller.sv.GetById(id)
+
+	if err != nil {
+		response.Error(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	var buyerRequest BuyerRequestPatch
+	if err := json.NewDecoder(r.Body).Decode(&buyerRequest); err != nil {
+		response.JSON(w, http.StatusBadRequest, "Error ao decodificarJSON")
+		return
+	}
+
+	if buyerRequest.Id == nil {
+		buyerRequest.Id = &buyer.Id
+	}
+	if buyerRequest.CardNumberId == nil {
+		buyerRequest.CardNumberId = &buyer.CardNumberId
+	}
+	if buyerRequest.FirstName == nil {
+		buyerRequest.FirstName = &buyer.FirstName
+	}
+	if buyerRequest.LastName == nil {
+		buyerRequest.LastName = &buyer.LastName
+	}
+
+	buyerToUpdate := modelsBuyer.Buyer{
+		Id:           id,
+		CardNumberId: *buyerRequest.CardNumberId,
+		FirstName:    *buyerRequest.FirstName,
+		LastName:     *&buyer.LastName,
+	}
+
+	errToPatch := controller.sv.PatchBuyer(buyerToUpdate)
+
+	if errToPatch != nil {
+		response.Error(w, http.StatusInternalServerError, "Failed to done the patch")
+		return
+	}
+
+	data := BuyerDataResJSON{
+		Id:           buyerToUpdate.Id,
+		CardNumberId: buyerToUpdate.CardNumberId,
+		FirstName:    buyerToUpdate.FirstName,
+		LastName:     buyerToUpdate.LastName,
+	}
+
+	res := BuyerResJSON{
+		Message: "Success",
+		Data:    data,
+	}
+	response.JSON(w, http.StatusOK, res)
+
+}

--- a/internal/models/buyer/buyer.go
+++ b/internal/models/buyer/buyer.go
@@ -6,3 +6,10 @@ type Buyer struct {
 	FirstName    string
 	LastName     string
 }
+
+type BuyerDTO struct {
+	Id           *int    `json:"id,omitempty"`
+	CardNumberId *string `json:"card_number_id,omitempty"`
+	FirstName    *string `json:"first_name,omitempty"`
+	LastName     *string `json:"last_name,omitempty"`
+}

--- a/internal/models/buyer/buyer_repository.go
+++ b/internal/models/buyer/buyer_repository.go
@@ -5,5 +5,5 @@ type BuyerRepository interface {
 	GetById(id int) (buyer Buyer, err error)
 	GetByCardNumberId(cardNumberId string) (buyer Buyer, err error)
 	PostBuyer(buyer Buyer) (buyerReturn Buyer, err error)
-	PatchBuyer(buyer Buyer) (err error)
+	PatchBuyer(buyer BuyerDTO) (buyerReturn Buyer, err error)
 }

--- a/internal/models/buyer/buyer_repository.go
+++ b/internal/models/buyer/buyer_repository.go
@@ -5,4 +5,5 @@ type BuyerRepository interface {
 	GetById(id int) (buyer Buyer, err error)
 	GetByCardNumberId(cardNumberId string) (buyer Buyer, err error)
 	PostBuyer(buyer Buyer) (buyerReturn Buyer, err error)
+	PatchBuyer(buyer Buyer) (err error)
 }

--- a/internal/models/buyer/buyer_service.go
+++ b/internal/models/buyer/buyer_service.go
@@ -5,5 +5,5 @@ type BuyerService interface {
 	GetById(id int) (buyer Buyer, err error)
 	GetByCardNumberId(cardNumberId string) (buyer Buyer, err error)
 	PostBuyer(buyer Buyer) (buyerReturn Buyer, err error)
-	PatchBuyer(buyer Buyer) (err error)
+	PatchBuyer(buyer BuyerDTO) (buyerReturn Buyer, err error)
 }

--- a/internal/models/buyer/buyer_service.go
+++ b/internal/models/buyer/buyer_service.go
@@ -5,4 +5,5 @@ type BuyerService interface {
 	GetById(id int) (buyer Buyer, err error)
 	GetByCardNumberId(cardNumberId string) (buyer Buyer, err error)
 	PostBuyer(buyer Buyer) (buyerReturn Buyer, err error)
+	PatchBuyer(buyer Buyer) (err error)
 }

--- a/internal/repository/buyer/buyer_default.go
+++ b/internal/repository/buyer/buyer_default.go
@@ -1,11 +1,17 @@
 package buyerRepository
 
-import modelsBuyer "github.com/maxwelbm/alkemy-g6/internal/models/buyer"
+import (
+	"errors"
+
+	modelsBuyer "github.com/maxwelbm/alkemy-g6/internal/models/buyer"
+)
 
 type BuyerRepository struct {
 	Buyers map[int]modelsBuyer.Buyer
 	NextID int
 }
+
+var ErrorIdNotFound = errors.New("Id not found")
 
 func NewBuyerRepository(db map[int]modelsBuyer.Buyer) *BuyerRepository {
 	repo := &BuyerRepository{

--- a/internal/repository/buyer/patch.go
+++ b/internal/repository/buyer/patch.go
@@ -1,8 +1,31 @@
 package buyerRepository
 
-import modelsBuyer "github.com/maxwelbm/alkemy-g6/internal/models/buyer"
+import (
+	modelsBuyer "github.com/maxwelbm/alkemy-g6/internal/models/buyer"
+)
 
-func (r *BuyerRepository) PatchBuyer(buyer modelsBuyer.Buyer) (err error) {
+func (r *BuyerRepository) PatchBuyer(buyerRequest modelsBuyer.BuyerDTO) (buyer modelsBuyer.Buyer, err error) {
+
+	buyer, err = r.GetById(*buyerRequest.Id)
+
+	if err != nil {
+		err = ErrorIdNotFound
+		return
+	}
+
+	if buyerRequest.Id != nil {
+		buyer.Id = *buyerRequest.Id
+	}
+	if buyerRequest.CardNumberId != nil {
+		buyer.CardNumberId = *buyerRequest.CardNumberId
+	}
+	if buyerRequest.FirstName != nil {
+		buyer.FirstName = *buyerRequest.FirstName
+	}
+	if buyerRequest.LastName != nil {
+		buyer.LastName = *buyerRequest.LastName
+	}
+
 	r.Buyers[buyer.Id] = buyer
-	return nil
+	return
 }

--- a/internal/repository/buyer/patch.go
+++ b/internal/repository/buyer/patch.go
@@ -1,0 +1,8 @@
+package buyerRepository
+
+import modelsBuyer "github.com/maxwelbm/alkemy-g6/internal/models/buyer"
+
+func (r *BuyerRepository) PatchBuyer(buyer modelsBuyer.Buyer) (err error) {
+	r.Buyers[buyer.Id] = buyer
+	return nil
+}

--- a/internal/service/buyer_default.go
+++ b/internal/service/buyer_default.go
@@ -29,3 +29,7 @@ func (s *BuyerDefault) GetByCardNumberId(cardNumberId string) (modelsBuyer.Buyer
 func (s *BuyerDefault) PostBuyer(buyer modelsBuyer.Buyer) (modelsBuyer.Buyer, error) {
 	return s.rp.PostBuyer(buyer)
 }
+
+func (s *BuyerDefault) PatchBuyer(buyer modelsBuyer.Buyer) error {
+	return s.rp.PatchBuyer(buyer)
+}

--- a/internal/service/buyer_default.go
+++ b/internal/service/buyer_default.go
@@ -30,6 +30,6 @@ func (s *BuyerDefault) PostBuyer(buyer modelsBuyer.Buyer) (modelsBuyer.Buyer, er
 	return s.rp.PostBuyer(buyer)
 }
 
-func (s *BuyerDefault) PatchBuyer(buyer modelsBuyer.Buyer) error {
+func (s *BuyerDefault) PatchBuyer(buyer modelsBuyer.BuyerDTO) (modelsBuyer.Buyer, error) {
 	return s.rp.PatchBuyer(buyer)
 }


### PR DESCRIPTION
Objetivo:
Adicionar endpoint para patch de buyer em /api/v1/buyers/:id referente ao requisito 6

Solução Proposta:
Controller: com o endpoint definido para patch de buyer
Service: com o método Patch
Repository: com a lógica para patch de um buyer

Retornamos 200 (OK) quando o buyer for atualizado.
Retornamos 404 (Not Found) quando o buyer não existir.