### PR TITLE
Feat/delete buyers

### DIFF
--- a/internal/application/init_buyer.go
+++ b/internal/application/init_buyer.go
@@ -23,6 +23,7 @@ func buildApiV1BuyerRoutes(rt *chi.Mux) {
 		rt.Get("/{id}", ct.GetById)
 		rt.Post("/", ct.PostBuyer)
 		rt.Patch("/{id}", ct.PatchBuyer)
+		rt.Delete("/{id}", ct.DeleteBuyer)
 	})
 }
 

--- a/internal/controllers/buyer/delete.go
+++ b/internal/controllers/buyer/delete.go
@@ -1,0 +1,31 @@
+package buyerController
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/maxwelbm/alkemy-g6/pkg/response"
+)
+
+func (controller *BuyerDefault) DeleteBuyer(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil || id < 1 {
+		response.Error(w, http.StatusBadRequest, "Failed to convert request id")
+		return
+	}
+
+	_, err = controller.sv.GetById(id)
+
+	if err != nil {
+		response.Error(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	controller.sv.Delete(id)
+
+	response.JSON(w, http.StatusNoContent, nil)
+
+}

--- a/internal/controllers/buyer/get_all.go
+++ b/internal/controllers/buyer/get_all.go
@@ -1,7 +1,6 @@
 package buyerController
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/maxwelbm/alkemy-g6/pkg/response"
@@ -11,7 +10,6 @@ func (controller *BuyerDefault) GetAll(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
 
 	buyers, err := controller.sv.GetAll()
-	fmt.Printf("data: %+v", buyers)
 
 	if err != nil {
 		response.Error(w, http.StatusInternalServerError, "Failed to retrieve buyers")

--- a/internal/models/buyer/buyer_repository.go
+++ b/internal/models/buyer/buyer_repository.go
@@ -6,4 +6,5 @@ type BuyerRepository interface {
 	GetByCardNumberId(cardNumberId string) (buyer Buyer, err error)
 	PostBuyer(buyer Buyer) (buyerReturn Buyer, err error)
 	PatchBuyer(buyer Buyer) (err error)
+	Delete(id int) (err error)
 }

--- a/internal/models/buyer/buyer_service.go
+++ b/internal/models/buyer/buyer_service.go
@@ -6,4 +6,5 @@ type BuyerService interface {
 	GetByCardNumberId(cardNumberId string) (buyer Buyer, err error)
 	PostBuyer(buyer Buyer) (buyerReturn Buyer, err error)
 	PatchBuyer(buyer Buyer) (err error)
+	Delete(id int) (err error)
 }

--- a/internal/repository/buyer/delete.go
+++ b/internal/repository/buyer/delete.go
@@ -1,0 +1,6 @@
+package buyerRepository
+
+func (r *BuyerRepository) Delete(id int) (err error) {
+	delete(r.Buyers, id)
+	return nil
+}

--- a/internal/service/buyer_default.go
+++ b/internal/service/buyer_default.go
@@ -33,3 +33,7 @@ func (s *BuyerDefault) PostBuyer(buyer modelsBuyer.Buyer) (modelsBuyer.Buyer, er
 func (s *BuyerDefault) PatchBuyer(buyer modelsBuyer.Buyer) error {
 	return s.rp.PatchBuyer(buyer)
 }
+
+func (s *BuyerDefault) Delete(id int) (err error) {
+	return s.rp.Delete(id)
+}


### PR DESCRIPTION
Objetivo:
Adicionar endpoint para delete de buyer em /api/v1/buyers/:id referente ao requisito 6

Solução Proposta:
Controller: com o endpoint definido para delete de buyer
Service: com o método Delete
Repository: com a lógica para delete de um buyer

Retornamos 204 (Not Content) quando o buyer for deletado.
Retornamos 404 (Not Found) quando o buyer não existir.