### PR TITLE
Fix: Req1 listar todos os reports caso o parametro seja vazio

### DIFF
--- a/internal/models/locality.go
+++ b/internal/models/locality.go
@@ -27,10 +27,10 @@ type LocalitySellersReport struct {
 
 type LocalityService interface {
 	Create(locDTO LocalityDTO) (loc Locality, err error)
-	ReportSellers(id int) (report LocalitySellersReport, err error)
+	ReportSellers(id int) (reports []LocalitySellersReport, err error)
 }
 
 type LocalityRepository interface {
 	Create(locDTO LocalityDTO) (loc Locality, err error)
-	ReportSellers(id int) (report LocalitySellersReport, err error)
+	ReportSellers(id int) (reports []LocalitySellersReport, err error)
 }

--- a/internal/repository/localities/report_sellers.go
+++ b/internal/repository/localities/report_sellers.go
@@ -1,32 +1,38 @@
 package localities_repository
 
 import (
-	"database/sql"
-	"errors"
-
 	"github.com/maxwelbm/alkemy-g6/internal/models"
 )
 
-func (r *LocalityRepository) ReportSellers(id int) (report models.LocalitySellersReport, err error) {
+func (r *LocalityRepository) ReportSellers(id int) (reports []models.LocalitySellersReport, err error) {
 	// selects locality info and seller count
 	query := `
 		SELECT l.id, l.locality_name, COUNT(s.id) AS sellers_count
 		FROM localities AS l
 		LEFT JOIN sellers AS s ON l.id = s.locality_id
-		WHERE l.id = ?
-		GROUP BY l.id;
+		WHERE (? = 0 OR l.id = ?)
+		GROUP BY l.id
 	`
-	row := r.db.QueryRow(query, id)
-	// scans row into report
-	err = row.Scan(&report.ID, &report.LocalityName, &report.SellersCount)
-
-	// check for errors
+	rows, err := r.db.Query(query, id, id)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			err = models.ErrLocalityNotFound
-			return
-		}
 		return
 	}
+	defer rows.Close()
+	// scans row into report
+	for rows.Next() {
+		var report models.LocalitySellersReport
+		if err = rows.Scan(&report.ID, &report.LocalityName, &report.SellersCount); err != nil {
+			return
+		}
+		reports = append(reports, report)
+	}
+	if len(reports) == 0 {
+		err = models.ErrLocalityNotFound
+		return
+	}
+	if err = rows.Err(); err != nil {
+		return
+	}
+
 	return
 }

--- a/internal/service/locality_default.go
+++ b/internal/service/locality_default.go
@@ -10,8 +10,8 @@ func NewLocalityDefault(rp models.LocalityRepository) *LocalityDefault {
 	return &LocalityDefault{rp: rp}
 }
 
-func (s *LocalityDefault) ReportSellers(id int) (report models.LocalitySellersReport, err error) {
-	report, err = s.rp.ReportSellers(id)
+func (s *LocalityDefault) ReportSellers(id int) (reports []models.LocalitySellersReport, err error) {
+	reports, err = s.rp.ReportSellers(id)
 	return
 }
 


### PR DESCRIPTION
## Motivação

Um dos requisitos do endpoint /api/v1/localities/reportSellers era de que, caso o parametro id não esteja presente, retornar uma listagem de reports de todos os sellers

## Solução proposta

Adiciona logica condicional no controller e repository para tratar o caso do id vazio