### PR TITLE
feat/GET purchase order reports

### DIFF
--- a/internal/application/resources/buyers.go
+++ b/internal/application/resources/buyers.go
@@ -23,5 +23,6 @@ func InitBuyers(db *sql.DB, router *chi.Mux) {
 		rt.Post("/", ct.Create)
 		rt.Patch("/{id}", ct.Update)
 		rt.Delete("/{id}", ct.Delete)
+		rt.Get("/reportPurchaseOrders", ct.ReportPurchaseOrders)
 	})
 }

--- a/internal/controllers/buyer/report_purchase_orders.go
+++ b/internal/controllers/buyer/report_purchase_orders.go
@@ -1,0 +1,53 @@
+package buyers_controller
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/response"
+)
+
+func (ct *BuyersDefault) ReportPurchaseOrders(w http.ResponseWriter, r *http.Request) {
+	var id int
+	var err error
+
+	param := r.URL.Query().Get("id")
+	if param != "" {
+		id, err = strconv.Atoi(param)
+		if err != nil {
+			response.Error(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if id < 1 {
+			response.Error(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+			return
+		}
+	}
+	list, err := ct.SV.ReportPurchaseOrders(id)
+	if err != nil {
+		if errors.Is(err, models.ErrBuyerNotFound) {
+			response.Error(w, http.StatusNotFound, err.Error())
+			return
+		}
+
+		response.Error(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var data []models.BuyerPurchaseOrdersReportJSON
+	for _, value := range list {
+		result := models.BuyerPurchaseOrdersReportJSON{
+			Id:                  value.ID,
+			CardNumberId:        value.CardNumberId,
+			FirstName:           value.FirstName,
+			LastName:            value.LastName,
+			PurchaseOrdersCount: value.PurchaseOrdersCount,
+		}
+		data = append(data, result)
+	}
+
+	res := BuyerResJSON{Data: data}
+	response.JSON(w, http.StatusOK, res)
+}

--- a/internal/models/buyers.go
+++ b/internal/models/buyers.go
@@ -19,6 +19,26 @@ type BuyerDTO struct {
 	FirstName    *string `json:"first_name,omitempty"`
 	LastName     *string `json:"last_name,omitempty"`
 }
+type BuyerPurchaseOrdersReportJSON struct {
+	Id                  int    `json:"id,omitempty"`
+	CardNumberId        string `json:"card_number_id,omitempty"`
+	FirstName           string `json:"first_name,omitempty"`
+	LastName            string `json:"last_name,omitempty"`
+	PurchaseOrdersCount int    `json:"purchase_orders_count"`
+}
+
+type BuyerPurchaseOrdersReport struct {
+	ID                  int
+	CardNumberId        string
+	FirstName           string
+	LastName            string
+	PurchaseOrdersCount int
+}
+
+type BuyerResJSON struct {
+	Message string `json:"message,omitempty"`
+	Data    any    `json:"data,omitempty"`
+}
 
 type BuyerService interface {
 	GetAll() (buyers []Buyer, err error)
@@ -27,6 +47,7 @@ type BuyerService interface {
 	Create(buyer BuyerDTO) (buyerReturn Buyer, err error)
 	Update(id int, buyer BuyerDTO) (buyerReturn Buyer, err error)
 	Delete(id int) (err error)
+	ReportPurchaseOrders(id int) (reports []BuyerPurchaseOrdersReport, err error)
 }
 
 type BuyerRepository interface {
@@ -36,4 +57,5 @@ type BuyerRepository interface {
 	Create(buyer BuyerDTO) (buyerReturn Buyer, err error)
 	Update(id int, buyer BuyerDTO) (buyerReturn Buyer, err error)
 	Delete(id int) (err error)
+	ReportPurchaseOrders(id int) (reports []BuyerPurchaseOrdersReport, err error)
 }

--- a/internal/repository/buyers/reports_purchase_orders.go
+++ b/internal/repository/buyers/reports_purchase_orders.go
@@ -1,0 +1,38 @@
+package buyers_repository
+
+import (
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+)
+
+func (r *BuyerRepository) ReportPurchaseOrders(id int) (reports []models.BuyerPurchaseOrdersReport, err error) {
+	query := `
+		SELECT b.id, b.card_number_id, b.first_name, b.last_name, COUNT(p.id) purchase_orders_count
+		FROM buyers b
+		JOIN purchase_orders p ON b.id = p.buyer_id
+		WHERE (? = 0 OR b.id = ?)
+		GROUP BY b.id
+	`
+	rows, err := r.DB.Query(query, id, id)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var report models.BuyerPurchaseOrdersReport
+		err = rows.Scan(&report.ID, &report.CardNumberId, &report.FirstName, &report.LastName, &report.PurchaseOrdersCount)
+		if err != nil {
+			return
+		}
+		reports = append(reports, report)
+	}
+	if len(reports) == 0 {
+		err = models.ErrBuyerNotFound
+		return
+	}
+	if err = rows.Err(); err != nil {
+		return
+	}
+
+	return
+}

--- a/internal/service/buyer_default.go
+++ b/internal/service/buyer_default.go
@@ -43,3 +43,8 @@ func (s *BuyerDefault) Delete(id int) (err error) {
 	err = s.rp.Delete(id)
 	return
 }
+
+func (s *BuyerDefault) ReportPurchaseOrders(id int) (reports []models.BuyerPurchaseOrdersReport, err error) {
+	reports, err = s.rp.ReportPurchaseOrders(id)
+	return
+}


### PR DESCRIPTION
### **Implementação do Relatório de Purchase Orders por Comprador**

Os seguintes cenários de teste foram abordados:

**Cenário 1:** O Comprador Não Existe
Dado que o comprador enviado não existe no sistema,
Então o representante deve gerar o relatório:
E o sistema retorna um erro 404, sinalizando que o comprador não foi encontrado

**Cenário 2:** O Comprador Existe
Dado que o comprador enviado existe no sistema,
Então o representante deve gerar o relatório:
E o sistema retorna um relatório contendo o número de Purchase Orders para o comprador específico

**Cenário 3:** Nenhum Comprador Enviado
Dado que nenhum comprador é enviado,
Então o representante deve gerar o relatório:
E o sistema retorna um relatório com o número total de Purchase Orders para cada comprador existente no sistema

**Validação**
A funcionalidade inclui uma validação para verificar se o comprador existe no sistema antes de tentar gerar o relatório
