### PR TITLE
Feat/test sellers get endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,12 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
+)
+
+require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -19,6 +25,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/files v1.0.1 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/swaggo/files v1.0.1 h1:J1bVJ4XHZNq0I46UU90611i9/YzdrF7x92oX1ig5IdE=
 github.com/swaggo/files v1.0.1/go.mod h1:0qXmMNH6sXNf+73t65aKeB+ApmgxdnkQzVTAj2uaMUg=
 github.com/swaggo/http-swagger v1.3.4 h1:q7t/XLx0n15H1Q9/tk3Y9L4n210XzJF5WtnDX64a5ww=

--- a/internal/controllers/seller/get_all_test.go
+++ b/internal/controllers/seller/get_all_test.go
@@ -1,0 +1,96 @@
+package sellersctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	sellersctl "github.com/maxwelbm/alkemy-g6/internal/controllers/seller"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAll(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+	}
+	tests := []struct {
+		name    string
+		sellers []models.Seller
+		callErr error
+		wanted  wanted
+	}{
+		{
+			name: "200 - When sellers are registered in the database",
+			sellers: []models.Seller{
+				{ID: 1, CID: "123", CompanyName: "Acme Corp", Address: "123 Elm St", Telephone: "555-1234", LocalityID: 1},
+				{ID: 2, CID: "456", CompanyName: "Globex Inc", Address: "456 Oak St", Telephone: "555-1235", LocalityID: 2},
+				{ID: 3, CID: "789", CompanyName: "Soylent Corp", Address: "789 Pine St", Telephone: "555-1236", LocalityID: 3},
+			},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name:    "200 - When no sellers are registered in the database",
+			sellers: []models.Seller{},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name:    "500 - When the service returns an error",
+			sellers: []models.Seller{},
+			callErr: errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewSellersServiceMock()
+			ctl := controllers.NewSellersController(sv)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/sellers", nil)
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("GetAll").Return(tt.sellers, tt.callErr)
+			ctl.GetAll(res, req)
+
+			var decodedRes struct {
+				Message string                      `json:"message,omitempty"`
+				Data    []sellersctl.FullSellerJSON `json:"data,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			// Assert
+			sv.AssertNumberOfCalls(t, "GetAll", tt.wanted.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			if len(tt.sellers) > 0 {
+				for i, seller := range tt.sellers {
+					require.Equal(t, seller.ID, decodedRes.Data[i].ID)
+					require.Equal(t, seller.CID, decodedRes.Data[i].CID)
+					require.Equal(t, seller.CompanyName, decodedRes.Data[i].CompanyName)
+				}
+			}
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/controllers/seller/get_by_id_test.go
+++ b/internal/controllers/seller/get_by_id_test.go
@@ -1,0 +1,100 @@
+package sellersctl_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	sellersctl "github.com/maxwelbm/alkemy-g6/internal/controllers/seller"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetByID(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+		seller     models.Seller
+	}
+	tests := []struct {
+		name    string
+		id      string
+		callErr error
+		wanted  struct {
+			calls      int
+			statusCode int
+			message    string
+			seller     models.Seller
+		}
+	}{
+		{
+			name:    "200 - When the seller is found",
+			id:      "1",
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+				seller:     models.Seller{ID: 1, CID: "CID123", CompanyName: "Company 1", Address: "123 Street", Telephone: "123456789", LocalityID: 1},
+			},
+		},
+		{
+			name:    "400 - When passing a non numeric id",
+			id:      "abc",
+			callErr: nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name:    "404 - When the repository raises a NotFound error",
+			id:      "999",
+			callErr: models.ErrSellerNotFound,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "seller not found",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewSellersServiceMock()
+			ctl := controllers.NewSellersController(sv)
+
+			r := chi.NewRouter()
+			r.Get("/api/v1/Sellers/{id}", ctl.GetByID)
+			url := "/api/v1/Sellers/" + string(tt.id)
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("GetByID", mock.AnythingOfType("int")).Return(tt.wanted.seller, tt.callErr)
+			r.ServeHTTP(res, req)
+			ctl.GetByID(res, req)
+
+			var decodedRes struct {
+				Message string                    `json:"message,omitempty"`
+				Data    sellersctl.FullSellerJSON `json:"data,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			// Assert
+			sv.AssertNumberOfCalls(t, "GetByID", tt.wanted.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			require.Equal(t, decodedRes.Data.ID, tt.wanted.seller.ID)
+			require.Equal(t, decodedRes.Data.CID, tt.wanted.seller.CID)
+			require.Equal(t, decodedRes.Data.CompanyName, tt.wanted.seller.CompanyName)
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/repository/sellers/seller_mock.go
+++ b/internal/repository/sellers/seller_mock.go
@@ -1,0 +1,29 @@
+package sellersrp
+
+import (
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/stretchr/testify/mock"
+)
+
+type SellerRepositoryMock struct {
+	mock.Mock
+}
+
+func NewSellersRepositoryMock() *SellerRepositoryMock {
+	return &SellerRepositoryMock{}
+}
+
+func (m *SellerRepositoryMock) GetAll() ([]models.Seller, error) {
+	args := m.Called()
+	return args.Get(0).([]models.Seller), args.Error(1)
+}
+
+func (m *SellerRepositoryMock) GetByID(id int) (models.Seller, error) {
+	args := m.Called(id)
+	return args.Get(0).(models.Seller), args.Error(1)
+}
+
+func (m *SellerRepositoryMock) GetByCID(CID int) (models.Seller, error) {
+	args := m.Called(CID)
+	return args.Get(0).(models.Seller), args.Error(1)
+}

--- a/internal/repository/sellers/seller_mock.go
+++ b/internal/repository/sellers/seller_mock.go
@@ -23,7 +23,22 @@ func (m *SellerRepositoryMock) GetByID(id int) (models.Seller, error) {
 	return args.Get(0).(models.Seller), args.Error(1)
 }
 
-func (m *SellerRepositoryMock) GetByCID(CID int) (models.Seller, error) {
+func (m *SellerRepositoryMock) GetByCid(CID int) (models.Seller, error) {
 	args := m.Called(CID)
 	return args.Get(0).(models.Seller), args.Error(1)
+}
+
+func (m *SellerRepositoryMock) Create(seller models.SellerDTO) (models.Seller, error) {
+	args := m.Called(seller)
+	return args.Get(0).(models.Seller), args.Error(1)
+}
+
+func (m *SellerRepositoryMock) Update(id int, Seller models.SellerDTO) (SellerReturn models.Seller, err error) {
+	args := m.Called(id, Seller)
+	return args.Get(0).(models.Seller), args.Error(1)
+}
+
+func (m *SellerRepositoryMock) Delete(id int) error {
+	args := m.Called(id)
+	return args.Error(0)
 }

--- a/internal/service/seller_default_test.go
+++ b/internal/service/seller_default_test.go
@@ -1,0 +1,143 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	sellersrp "github.com/maxwelbm/alkemy-g6/internal/repository/sellers"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestSellersDefault_GetAll(t *testing.T) {
+	rp := sellersrp.NewSellersRepositoryMock()
+	rp.On("GetAll").Return([]models.Seller{
+		{
+			ID:          1,
+			CID:         "123",
+			CompanyName: "Company A",
+			Address:     "123 Street",
+			Telephone:   "012345678",
+			LocalityID:  1,
+		}, {
+			ID:          2,
+			CID:         "456",
+			CompanyName: "Company B",
+			Address:     "456 Street",
+			Telephone:   "123456789",
+			LocalityID:  2,
+		}, {
+			ID:          1,
+			CID:         "789",
+			CompanyName: "Company C",
+			Address:     "789 Street",
+			Telephone:   "234567890",
+			LocalityID:  3,
+		},
+	}, nil)
+
+	s := service.NewSellersService(rp)
+	sellers, err := s.GetAll()
+
+	assert.NoError(t, err)
+	assert.Len(t, sellers, 3)
+	assert.Equal(t, "Company A", sellers[0].CompanyName)
+	assert.Equal(t, "Company B", sellers[1].CompanyName)
+	assert.Equal(t, "Company C", sellers[2].CompanyName)
+}
+
+func TestSellersDefault_GetByID(t *testing.T) {
+	rp := sellersrp.NewSellersRepositoryMock()
+
+	rp.On("GetByID", mock.AnythingOfType("int")).Return(models.Seller{
+		ID:          1,
+		CID:         "123",
+		CompanyName: "Company A",
+		Address:     "123 Street",
+		Telephone:   "012345678",
+		LocalityID:  1,
+	}, nil)
+
+	s := service.NewSellersService(rp)
+	seller, err := s.GetByID(1)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Company A", seller.CompanyName)
+}
+
+func TestSellersDefault_GetByCid(t *testing.T) {
+	rp := sellersrp.NewSellersRepositoryMock()
+
+	rp.On("GetByCid", mock.AnythingOfType("int")).Return(models.Seller{
+		ID:          1,
+		CID:         "123",
+		CompanyName: "Company A",
+		Address:     "123 Street",
+		Telephone:   "012345678",
+		LocalityID:  1,
+	}, nil)
+
+	s := service.NewSellersService(rp)
+	seller, err := s.GetByCid(1)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "123", seller.CID)
+}
+
+/*
+func TestSellersDefault_Create(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRepo := models.NewMockSellersRepository(ctrl)
+	mockRepo.EXPECT().Create(models.SellerDTO{}).Return(models.Seller{}, nil)
+
+	s := service.NewSellersService(mockRepo)
+	seller, err := s.Create(models.SellerDTO{})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, seller)
+}
+
+func TestSellersDefault_Update(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRepo := models.NewMockSellersRepository(ctrl)
+	mockRepo.EXPECT().Update(1, models.SellerDTO{}).Return(models.Seller{}, nil)
+
+	s := service.NewSellersService(mockRepo)
+	seller, err := s.Update(1, models.SellerDTO{})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, seller)
+}
+
+func TestSellersDefault_Delete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRepo := models.NewMockSellersRepository(ctrl)
+	mockRepo.EXPECT().Delete(1).Return(nil)
+
+	s := service.NewSellersService(mockRepo)
+	err := s.Delete(1)
+
+	assert.NoError(t, err)
+}
+
+func TestSellersDefault_GetByID_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRepo := models.NewMockSellersRepository(ctrl)
+	mockRepo.EXPECT().GetByID(1).Return(models.Seller{}, errors.New("not found"))
+
+	s := service.NewSellersService(mockRepo)
+	seller, err := s.GetByID(1)
+
+	assert.Error(t, err)
+	assert.Equal(t, models.Seller{}, seller)
+}
+*/

--- a/internal/service/seller_mock.go
+++ b/internal/service/seller_mock.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/stretchr/testify/mock"
+)
+
+type SellerServiceMock struct {
+	mock.Mock
+}
+
+func NewSellersServiceMock() *SellerServiceMock {
+	return &SellerServiceMock{}
+}
+
+func (m *SellerServiceMock) GetAll() ([]models.Seller, error) {
+	args := m.Called()
+	return args.Get(0).([]models.Seller), args.Error(1)
+}
+
+func (m *SellerServiceMock) GetByID(id int) (models.Seller, error) {
+	args := m.Called(id)
+	return args.Get(0).(models.Seller), args.Error(1)
+}
+
+func (m *SellerServiceMock) GetByCid(CID int) (models.Seller, error) {
+	args := m.Called(CID)
+	return args.Get(0).(models.Seller), args.Error(1)
+}
+
+func (m *SellerServiceMock) Create(seller models.SellerDTO) (sellerToReturn models.Seller, err error) {
+	args := m.Called(seller)
+	return args.Get(0).(models.Seller), args.Error(1)
+}
+
+func (m *SellerServiceMock) Update(id int, seller models.SellerDTO) (sellerToReturn models.Seller, err error) {
+	args := m.Called(id, seller)
+	return args.Get(0).(models.Seller), args.Error(1)
+}
+
+func (m *SellerServiceMock) Delete(id int) (err error) {
+	args := m.Called(id)
+	return args.Error(1)
+}


### PR DESCRIPTION
Motivação
Implementar testes unitários seguindo as especificações da historia: https://github.com/maxwelbm/alkemy-g6/issues/131

Solução proposta
Implementa testes unitários nos controllers:

GET /api/v1/sellers/
GET /api/v1/sellers/{id}

Implementa testes unitários em alguns metodos do service:
GetAll
GetByID
GetByCid

Como testar
rode os testes automatizados com make test

Link p/ história
https://github.com/maxwelbm/alkemy-g6/issues/131