### PR TITLE
Feat/buyers ctrl test get

### DIFF
--- a/internal/controllers/buyer/get_all_test.go
+++ b/internal/controllers/buyer/get_all_test.go
@@ -1,0 +1,96 @@
+package buyersctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	buyersctl "github.com/maxwelbm/alkemy-g6/internal/controllers/buyer"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAll(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+	}
+	tests := []struct {
+		name    string
+		buyers  []models.Buyer
+		callErr error
+		wanted  wanted
+	}{
+		{
+			name: "200 - When buyers are registered in the database",
+			buyers: []models.Buyer{
+				{ID: 1, FirstName: "Buyer 1", LastName: "Ferreira", CardNumberID: "123456789"},
+				{ID: 2, FirstName: "Buyer 2", LastName: "Ferreira", CardNumberID: "987654321"},
+				{ID: 3, FirstName: "Buyer 3", LastName: "Ferreira", CardNumberID: "111111111"},
+			},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name:    "200 - When no buyers are registered in the database",
+			buyers:  []models.Buyer{},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name:    "500 - When the repository returns an error",
+			buyers:  []models.Buyer{},
+			callErr: errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewBuyersServiceMock()
+			ctl := controllers.NewBuyersController(sv)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/buyers", nil)
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("GetAll").Return(tt.buyers, tt.callErr)
+			ctl.GetAll(res, req)
+
+			var decodedRes struct {
+				Message string                    `json:"message,omitempty"`
+				Data    []buyersctl.FullBuyerJSON `json:"data,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			// Assert
+			sv.AssertNumberOfCalls(t, "GetAll", tt.wanted.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			if len(tt.buyers) > 0 {
+				for i, buyer := range tt.buyers {
+					require.Equal(t, buyer.FirstName, decodedRes.Data[i].FirstName)
+					require.Equal(t, buyer.LastName, decodedRes.Data[i].LastName)
+					require.Equal(t, buyer.CardNumberID, decodedRes.Data[i].CardNumberID)
+				}
+			}
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/controllers/buyer/get_by_id.go
+++ b/internal/controllers/buyer/get_by_id.go
@@ -1,10 +1,12 @@
 package buyersctl
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
 	"github.com/maxwelbm/alkemy-g6/pkg/response"
 )
 
@@ -22,17 +24,29 @@ import (
 func (ct *BuyersDefault) GetByID(w http.ResponseWriter, r *http.Request) {
 	// Parse the buyer ID from the URL parameter and convert it to an integer
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))
-	if err != nil || id < 1 {
-		// If the ID is invalid, return a 400 Bad Request error
+	// If the ID is invalid, return a 400 Bad Request error
+	if err != nil {
 		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// If the ID is less than 1, return a 400 Bad Request error
+	if id < 1 {
+		response.Error(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
 		return
 	}
 
 	// Retrieve the buyer details from the service layer using the ID
 	buyer, err := ct.sv.GetByID(id)
 	if err != nil {
-		// If the buyer is not found, return a 404 Not Found error
-		response.Error(w, http.StatusNotFound, err.Error())
+		// If the buyer ID is not found, return a 404 Not Found response
+		if errors.Is(err, models.ErrBuyerNotFound) {
+			response.Error(w, http.StatusNotFound, err.Error())
+			return
+		}
+
+		// For any other errors, return a 500 Internal Server Error response
+		response.Error(w, http.StatusInternalServerError, err.Error())
+
 		return
 	}
 

--- a/internal/controllers/buyer/get_by_id_test.go
+++ b/internal/controllers/buyer/get_by_id_test.go
@@ -1,0 +1,119 @@
+package buyersctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	buyersctl "github.com/maxwelbm/alkemy-g6/internal/controllers/buyer"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetByID(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+		buyer      models.Buyer
+	}
+	tests := []struct {
+		name    string
+		id      string
+		callErr error
+		wanted  struct {
+			calls      int
+			statusCode int
+			message    string
+			buyer      models.Buyer
+		}
+	}{
+		{
+			name:    "200 - When buyers the buyer is found",
+			id:      "1",
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+				buyer:      models.Buyer{ID: 1, FirstName: "Buyer 1", LastName: "Ferreira", CardNumberID: "123456789"},
+			},
+		},
+		{
+			name:    "400 - When passing a non numeric id",
+			id:      "abc",
+			callErr: nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name:    "400 - When passing a negative id",
+			id:      "-1",
+			callErr: nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "Bad Request",
+			},
+		},
+		{
+			name:    "404 - When the respository raises a NotFound error",
+			id:      "999",
+			callErr: models.ErrBuyerNotFound,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "buyer not found",
+			},
+		},
+		{
+			name:    "500 - When the repository returns an error",
+			id:      "1",
+			callErr: errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewBuyersServiceMock()
+			ctl := controllers.NewBuyersController(sv)
+
+			r := chi.NewRouter()
+			r.Get("/api/v1/buyers/{id}", ctl.GetByID)
+			url := "/api/v1/buyers/" + string(tt.id)
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("GetByID", mock.AnythingOfType("int")).Return(tt.wanted.buyer, tt.callErr)
+			r.ServeHTTP(res, req)
+
+			var decodedRes struct {
+				Message string                  `json:"message,omitempty"`
+				Data    buyersctl.FullBuyerJSON `json:"data,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			// Assert
+			sv.AssertNumberOfCalls(t, "GetByID", tt.wanted.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			require.Equal(t, decodedRes.Data.FirstName, tt.wanted.buyer.FirstName)
+			require.Equal(t, decodedRes.Data.LastName, tt.wanted.buyer.LastName)
+			require.Equal(t, decodedRes.Data.CardNumberID, tt.wanted.buyer.CardNumberID)
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/controllers/buyer/report_purchase_orders_test.go
+++ b/internal/controllers/buyer/report_purchase_orders_test.go
@@ -1,0 +1,145 @@
+package buyersctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	buyersctl "github.com/maxwelbm/alkemy-g6/internal/controllers/buyer"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReportPurchaseOrders(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+	}
+	tests := []struct {
+		name    string
+		id      string
+		buyers  []models.BuyerPurchaseOrdersReport
+		callErr error
+		wanted  wanted
+	}{
+		{
+			name: "200 - When buyers are registered in the database and no id is passed",
+			buyers: []models.BuyerPurchaseOrdersReport{
+				{ID: 1, CardNumberID: "123456789", FirstName: "Buyer 1", LastName: "Ferreira", PurchaseOrdersCount: 1},
+				{ID: 2, CardNumberID: "987654321", FirstName: "Buyer 2", LastName: "Ferreira", PurchaseOrdersCount: 2},
+				{ID: 3, CardNumberID: "111111111", FirstName: "Buyer 3", LastName: "Ferreira", PurchaseOrdersCount: 3},
+			},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name: "200 - When buyers are registered in the database and a valid id is passed",
+			buyers: []models.BuyerPurchaseOrdersReport{
+				{ID: 2, CardNumberID: "987654321", FirstName: "Buyer 2", LastName: "Ferreira", PurchaseOrdersCount: 2},
+			},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name:    "200 - When no buyers are registered in the database and no id is passed",
+			id:      "2",
+			buyers:  []models.BuyerPurchaseOrdersReport{},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name:    "400 - When passing a non numeric id",
+			id:      "S2",
+			callErr: nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name:    "400 - When passing a negative id",
+			id:      "-1",
+			callErr: nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "Bad Request",
+			},
+		},
+		{
+			name:    "404 - When the respository raises a NotFound error",
+			id:      "999",
+			callErr: models.ErrBuyerNotFound,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "buyer not found",
+			},
+		},
+		{
+			name:    "500 - When the repository returns an error",
+			buyers:  []models.BuyerPurchaseOrdersReport{},
+			callErr: errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewBuyersServiceMock()
+			ctl := controllers.NewBuyersController(sv)
+
+			url := "/api/v1/buyers/reportPurchaseOrders"
+			if tt.id != "" {
+				url += fmt.Sprintf("?id=%s", tt.id)
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("ReportPurchaseOrders", mock.AnythingOfType("int")).Return(tt.buyers, tt.callErr)
+			ctl.ReportPurchaseOrders(res, req)
+
+			var decodedRes struct {
+				Message string                    `json:"message,omitempty"`
+				Data    []buyersctl.FullBuyerJSON `json:"data,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			// Assert
+			sv.AssertNumberOfCalls(t, "ReportPurchaseOrders", tt.wanted.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			if len(tt.buyers) > 0 {
+				for i, buyer := range tt.buyers {
+					require.Equal(t, buyer.FirstName, decodedRes.Data[i].FirstName)
+					require.Equal(t, buyer.LastName, decodedRes.Data[i].LastName)
+					require.Equal(t, buyer.CardNumberID, decodedRes.Data[i].CardNumberID)
+				}
+			}
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/models/buyers.go
+++ b/internal/models/buyers.go
@@ -3,7 +3,7 @@ package models
 import "errors"
 
 var (
-	ErrBuyerNotFound = errors.New("Buyer not found ")
+	ErrBuyerNotFound = errors.New("buyer not found ")
 )
 
 type Buyer struct {

--- a/internal/service/buyers_default_mock.go
+++ b/internal/service/buyers_default_mock.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/stretchr/testify/mock"
+)
+
+type BuyerDefaultMock struct {
+	mock.Mock
+}
+
+func NewBuyersServiceMock() *BuyerDefaultMock {
+	return &BuyerDefaultMock{}
+}
+
+func (m *BuyerDefaultMock) GetAll() ([]models.Buyer, error) {
+	args := m.Called()
+	return args.Get(0).([]models.Buyer), args.Error(1)
+}
+
+func (m *BuyerDefaultMock) GetByID(id int) (models.Buyer, error) {
+	args := m.Called(id)
+	return args.Get(0).(models.Buyer), args.Error(1)
+}
+
+func (m *BuyerDefaultMock) GetByCardNumberID(cardNumberID string) (models.Buyer, error) {
+	args := m.Called(cardNumberID)
+	return args.Get(0).(models.Buyer), args.Error(1)
+}
+
+func (m *BuyerDefaultMock) Create(buyer models.BuyerDTO) (models.Buyer, error) {
+	args := m.Called(buyer)
+	return args.Get(0).(models.Buyer), args.Error(1)
+}
+
+func (m *BuyerDefaultMock) Update(id int, buyer models.BuyerDTO) (buyerReturn models.Buyer, err error) {
+	args := m.Called(id, buyer)
+	return args.Get(0).(models.Buyer), args.Error(1)
+}
+
+func (m *BuyerDefaultMock) Delete(id int) error {
+	args := m.Called(id)
+	return args.Error(0)
+}
+
+func (m *BuyerDefaultMock) ReportPurchaseOrders(id int) ([]models.BuyerPurchaseOrdersReport, error) {
+	args := m.Called(id)
+	return args.Get(0).([]models.BuyerPurchaseOrdersReport), args.Error(1)
+}


### PR DESCRIPTION
## Motivação
<!-- Qual é a motivação por trás desta mudança? -->
Implementar testes automatizados no recurso buyers segundo as especificações do card: https://github.com/maxwelbm/alkemy-g6/issues/140

## Solução proposta
<!-- Quais mudanças esta PR propõe? -->
implementa mock de service de buyers
implementa testes unitários nos controllers das rotas:
- GET `/api/v1/buyers/`
- GET `/api/v1/buyers/{id}`
- GET `/api/v1/buyers/reportPurchaseOrders`

## Como testar
<!-- Descreva como testar as mudanças propostas. -->
rode os testes unitários com
```sh
make test /internal/controllers/buyers
s```

## Link p/ história
<!-- Link para qualquer história ou issue relacionada (se aplicável). -->
https://github.com/maxwelbm/alkemy-g6/issues/149

