### PR TITLE
Feat/buyers ctl test create update delete

### DIFF
--- a/internal/controllers/buyers/create.go
+++ b/internal/controllers/buyers/create.go
@@ -18,21 +18,35 @@ type BuyerCreateJSON struct {
 }
 
 func (j *BuyerCreateJSON) validate() (err error) {
-	var validationErrors []string
+	var validationErrors, nilPointerErrors []string
 
 	if j.FirstName == nil {
-		validationErrors = append(validationErrors, "error: first_name is required")
+		nilPointerErrors = append(nilPointerErrors, "error: attribute FirstName cannot be nil")
+	} else if j.FirstName != nil && *j.FirstName == "" {
+		validationErrors = append(validationErrors, "error: attribute FirstName cannot be empty")
 	}
 
 	if j.LastName == nil {
-		validationErrors = append(validationErrors, "error: last_name is required")
+		nilPointerErrors = append(nilPointerErrors, "error: attribute LastName cannot be nil")
+	} else if j.LastName != nil && *j.LastName == "" {
+		validationErrors = append(validationErrors, "error: attribute LastName cannot be empty")
 	}
 
-	if len(validationErrors) > 0 {
-		err = fmt.Errorf("validation errors: %v", validationErrors)
+	if j.CardNumberID == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute CardNumberID cannot be nil")
+	} else if j.CardNumberID != nil && *j.CardNumberID == "" {
+		validationErrors = append(validationErrors, "error: attribute CardNumberID cannot be empty")
 	}
 
-	return
+	if len(nilPointerErrors) > 0 || len(validationErrors) > 0 {
+		var allErrors []string
+		allErrors = append(allErrors, nilPointerErrors...)
+		allErrors = append(allErrors, validationErrors...)
+
+		err = fmt.Errorf("validation errors: %v", allErrors)
+	}
+
+	return err
 }
 
 // Create handles the creation of a new buyer.
@@ -52,7 +66,7 @@ func (ct *BuyersDefault) Create(w http.ResponseWriter, r *http.Request) {
 	var buyerRequest BuyerCreateJSON
 	if err := json.NewDecoder(r.Body).Decode(&buyerRequest); err != nil {
 		// If there's an error decoding the request, respond with a 400 Bad Request status
-		response.JSON(w, http.StatusBadRequest, err.Error())
+		response.Error(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/internal/controllers/buyers/create_test.go
+++ b/internal/controllers/buyers/create_test.go
@@ -1,0 +1,127 @@
+package buyersctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	buyersctl "github.com/maxwelbm/alkemy-g6/internal/controllers/buyers"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreate(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+		buyer      models.Buyer
+	}
+	tests := []struct {
+		name      string
+		buyerJSON string
+		callErr   error
+		wanted    wanted
+	}{
+		{
+			name:      "201 - When the buyer is created successfully",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": "123456789"}`,
+			callErr:   nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusCreated,
+				message:    "Created",
+				buyer:      models.Buyer{ID: 1, FirstName: "Buyer 1", LastName: "Ferreira", CardNumberID: "123456789"},
+			},
+		},
+		{
+			name:      "400 - When passing a body with invalid json",
+			buyerJSON: `{"first_name": 1, "last_name": "Ferreira", "card_number_id": 123456789}`,
+			callErr:   nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "json: cannot unmarshal",
+			},
+		},
+		{
+			name:      "422 - When passing a body with a valid json with missing parameters",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira"}`,
+			callErr:   nil,
+			wanted: wanted{
+				statusCode: http.StatusUnprocessableEntity,
+				message:    "error: attribute CardNumberID cannot be nil",
+			},
+		},
+		{
+			name:      "422 - When passing a body with a valid json with empty parameters",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": ""}`,
+			callErr:   nil,
+			wanted: wanted{
+				statusCode: http.StatusUnprocessableEntity,
+				message:    "error: attribute CardNumberID cannot be empty",
+			},
+		},
+		{
+			name:      "409 - When the repository raises a DuplicateEntry error",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": "123456789"}`,
+			callErr:   &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusConflict,
+				message:    "1062",
+				buyer:      models.Buyer{},
+			},
+		},
+		{
+			name:      "500 - When the repository returns an unexpected error",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": "123456789"}`,
+			callErr:   errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+				buyer:      models.Buyer{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewBuyersServiceMock()
+			ctl := controllers.NewBuyersController(sv)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/buyers", strings.NewReader(tt.buyerJSON))
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("Create", mock.AnythingOfType("models.BuyerDTO")).Return(tt.wanted.buyer, tt.callErr)
+			ctl.Create(res, req)
+
+			// Assert
+			var decodedRes struct {
+				Message string                  `json:"message,omitempty"`
+				Data    buyersctl.FullBuyerJSON `json:"data,omitempty"`
+			}
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&decodedRes))
+
+			sv.AssertNumberOfCalls(t, "Create", tt.wanted.calls)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+			if tt.wanted.statusCode == http.StatusCreated {
+				require.Equal(t, tt.wanted.buyer.FirstName, decodedRes.Data.FirstName)
+				require.Equal(t, tt.wanted.buyer.LastName, decodedRes.Data.LastName)
+				require.Equal(t, tt.wanted.buyer.CardNumberID, decodedRes.Data.CardNumberID)
+			}
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/controllers/buyers/delete.go
+++ b/internal/controllers/buyers/delete.go
@@ -23,11 +23,15 @@ import (
 // @Failure 404 {object} map[string]string "Not Found"
 // @Router /api/v1/buyers/{id} [delete]
 func (ct *BuyersDefault) Delete(w http.ResponseWriter, r *http.Request) {
-	// Parse the buyer ID from the URL parameter and convert it to an integer.
+	// Parse the buyer ID from the URL parameter and validate it
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))
-	if err != nil || id < 1 {
-		// If the ID is not valid, return a 400 Bad Request response.
+	if err != nil {
 		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if id < 1 {
+		response.Error(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
 		return
 	}
 

--- a/internal/controllers/buyers/delete_test.go
+++ b/internal/controllers/buyers/delete_test.go
@@ -1,0 +1,112 @@
+package buyersctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	buyersctl "github.com/maxwelbm/alkemy-g6/internal/controllers/buyers"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelete(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+	}
+	tests := []struct {
+		name    string
+		id      string
+		callErr error
+		wanted  wanted
+	}{
+		{
+			name:    "204 - When the buyer is deleted successfully",
+			id:      "1",
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNoContent,
+			},
+		},
+		{
+			name:    "400 - When passing a non numeric id",
+			id:      "abc",
+			callErr: nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name:    "400 - When passing a negative id",
+			id:      "-1",
+			callErr: nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "Bad Request",
+			},
+		},
+		{
+			name:    "404 - When the repository raises a BuyerNotFound error",
+			id:      "999",
+			callErr: models.ErrBuyerNotFound,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "buyer not found",
+			},
+		},
+		{
+			name:    "500 - When the repository returns an error",
+			id:      "1",
+			callErr: errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewBuyersServiceMock()
+			ctl := controllers.NewBuyersController(sv)
+
+			r := chi.NewRouter()
+			r.Delete("/api/v1/buyers/{id}", ctl.Delete)
+			url := "/api/v1/buyers/" + string(tt.id)
+			req := httptest.NewRequest(http.MethodDelete, url, nil)
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("Delete", mock.AnythingOfType("int")).Return(tt.callErr)
+			r.ServeHTTP(res, req)
+			ctl.Delete(res, req)
+
+			var decodedRes struct {
+				Message string                    `json:"message,omitempty"`
+				Data    []buyersctl.FullBuyerJSON `json:"data"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			// Assert
+			sv.AssertNumberOfCalls(t, "Delete", tt.wanted.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/controllers/buyers/update.go
+++ b/internal/controllers/buyers/update.go
@@ -23,22 +23,23 @@ type BuyerUpdateJSON struct {
 func (j *BuyerUpdateJSON) validate() (err error) {
 	var validationErrors []string
 
-	// Validate FirstName: cannot be empty if provided
+	if j.CardNumberID != nil && *j.CardNumberID == "" {
+		validationErrors = append(validationErrors, "error: attribute CardNumberID cannot be empty")
+	}
+
 	if j.FirstName != nil && *j.FirstName == "" {
 		validationErrors = append(validationErrors, "error: attribute FirstName cannot be empty")
 	}
 
-	// Validate LastName: cannot be empty if provided
 	if j.LastName != nil && *j.LastName == "" {
 		validationErrors = append(validationErrors, "error: attribute LastName cannot be empty")
 	}
 
-	// If there are validation errors, create an error with the details
 	if len(validationErrors) > 0 {
 		err = fmt.Errorf("validation errors: %v", validationErrors)
 	}
 
-	return
+	return err
 }
 
 // Update handles the HTTP request to update a buyer's information.
@@ -57,20 +58,25 @@ func (j *BuyerUpdateJSON) validate() (err error) {
 func (ct *BuyersDefault) Update(w http.ResponseWriter, r *http.Request) {
 	// Parse the buyer ID from the URL parameter and validate it
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))
-	if err != nil || id < 1 {
+	if err != nil {
 		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if id < 1 {
+		response.Error(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
 		return
 	}
 
 	// Decode the JSON request body into a BuyerUpdateJSON struct
 	var buyerRequest BuyerUpdateJSON
-	if err := json.NewDecoder(r.Body).Decode(&buyerRequest); err != nil {
-		response.JSON(w, http.StatusBadRequest, err)
+	if err = json.NewDecoder(r.Body).Decode(&buyerRequest); err != nil {
+		response.Error(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	// Validate the decoded request data
-	if err := buyerRequest.validate(); err != nil {
+	if err = buyerRequest.validate(); err != nil {
 		response.Error(w, http.StatusUnprocessableEntity, err.Error())
 		return
 	}
@@ -85,21 +91,15 @@ func (ct *BuyersDefault) Update(w http.ResponseWriter, r *http.Request) {
 	// Call the service layer to update the buyer information
 	buyerReturn, err := ct.sv.Update(id, buyerToUpdate)
 
-	// Handle the case where no changes were made
-	if errors.Is(err, models.ErrorNoChangesMade) {
-		response.Error(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
 	if err != nil {
-		//  Handle the case where the buyer ID is not found
-		if errors.Is(err, models.ErrBuyerNotFound) {
-			response.Error(w, http.StatusNotFound, err.Error())
-			return
-		}
 		// Handle the case where no changes were made
 		if errors.Is(err, models.ErrorNoChangesMade) {
 			response.Error(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		//  Handle the case where the buyer ID is not found
+		if errors.Is(err, models.ErrBuyerNotFound) {
+			response.Error(w, http.StatusNotFound, err.Error())
 			return
 		}
 		// Handle the case where a MySQL duplicate entry error occurred

--- a/internal/controllers/buyers/update_test.go
+++ b/internal/controllers/buyers/update_test.go
@@ -1,0 +1,173 @@
+package buyersctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-sql-driver/mysql"
+	buyersctl "github.com/maxwelbm/alkemy-g6/internal/controllers/buyers"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdate(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+		buyer      models.Buyer
+	}
+	tests := []struct {
+		name      string
+		id        string
+		buyerJSON string
+		callErr   error
+		wanted    wanted
+	}{
+		{
+			name:      "200 - When the buyer is updated successfully with all fields",
+			id:        "1",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": "123456789"}`,
+			callErr:   nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+				message:    "OK",
+				buyer:      models.Buyer{ID: 1, FirstName: "Buyer 1", LastName: "Ferreira", CardNumberID: "123456789"},
+			},
+		},
+		{
+			name:      "200 - When the buyer is updated successfully with missing fields",
+			id:        "1",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira"}`,
+			callErr:   nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+				message:    "OK",
+				buyer:      models.Buyer{ID: 1, FirstName: "Buyer 1", LastName: "Ferreira", CardNumberID: "123456789"},
+			},
+		},
+		{
+			name:      "400 - When passing a non numeric id",
+			id:        "abc",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": "123456789"}`,
+			callErr:   nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name:      "400 - When passing a negative id",
+			id:        "-1",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": "123456789"}`,
+			callErr:   nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "Bad Request",
+			},
+		},
+		{
+			name:      "400 - When passing a body with invalid json",
+			id:        "1",
+			buyerJSON: `{"first_name": 1, "last_name": "Ferreira", "card_number_id": 123456789}`,
+			callErr:   nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "json: cannot unmarshal",
+			},
+		},
+		{
+			name:      "404 - When the repository raises a BuyerNotFound error",
+			id:        "999",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": "12345678"}`,
+			callErr:   models.ErrBuyerNotFound,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "buyer not found",
+			},
+		},
+		{
+			name:      "409 - When the repository raises a DuplicateEntry error",
+			id:        "1",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": "12345678"}`,
+			callErr:   &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusConflict,
+				message:    "1062",
+			},
+		},
+		{
+			name:      "422 - When passing a body with empty fields",
+			id:        "1",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": ""}`,
+			callErr:   nil,
+			wanted: wanted{
+				statusCode: http.StatusUnprocessableEntity,
+				message:    "error: attribute CardNumberID cannot be empty",
+			},
+		},
+		{
+			name:      "500 - When the repository returns an error",
+			id:        "1",
+			buyerJSON: `{"first_name": "Buyer 1", "last_name": "Ferreira", "card_number_id": "123456789"}`,
+			callErr:   errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewBuyersServiceMock()
+			ctl := buyersctl.NewBuyersController(sv)
+
+			r := chi.NewRouter()
+			r.Patch("/api/v1/buyers/{id}", ctl.Update)
+			url := "/api/v1/buyers/" + string(tt.id)
+			req := httptest.NewRequest(http.MethodPatch, url, strings.NewReader(tt.buyerJSON))
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On(
+				"Update",
+				mock.AnythingOfType("int"),
+				mock.AnythingOfType("models.BuyerDTO"),
+			).Return(tt.wanted.buyer, tt.callErr)
+			r.ServeHTTP(res, req)
+			ctl.Update(res, req)
+
+			// Assert
+			var decodedRes struct {
+				Message string       `json:"message,omitempty"`
+				Data    models.Buyer `json:"data,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+			require.NoError(t, err)
+
+			sv.AssertNumberOfCalls(t, "Update", tt.wanted.calls)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+			if tt.callErr != nil {
+				require.Equal(t, tt.wanted.buyer.FirstName, decodedRes.Data.FirstName)
+				require.Equal(t, tt.wanted.buyer.LastName, decodedRes.Data.LastName)
+				require.Equal(t, tt.wanted.buyer.CardNumberID, decodedRes.Data.CardNumberID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivação
<!-- Qual é a motivação por trás desta mudança? -->
Implementar testes unitários seguindo as especificações da historia: https://github.com/maxwelbm/alkemy-g6/issues/140


## Solução proposta
<!-- Quais mudanças esta PR propõe? -->
Esse card aborda os endpoints de create, update e delete do recurso `buyers`, os endpoints testados são:
- POST `/api/v1/buyers/`
- PATCH `/api/v1/buyers/{id}`
- DELETE `/api/v1/buyers/{id}`

## Como testar
<!-- Descreva como testar as mudanças propostas. -->
Execute os testes do controller com
```sh
make test internal/controllers/buyers
```

## Link p/ história
<!-- Link para qualquer história ou issue relacionada (se aplicável). -->
https://github.com/maxwelbm/alkemy-g6/issues/159

