### PR TITLE
Test controller delete products

### DIFF
--- a/internal/controllers/products/delete.go
+++ b/internal/controllers/products/delete.go
@@ -32,6 +32,11 @@ func (p *ProductsDefault) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if id < 1 {
+		response.Error(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+		return
+	}
+
 	err = p.SV.Delete(id)
 	if errors.Is(err, models.ErrProductNotFound) {
 		response.Error(w, http.StatusNotFound, err.Error())

--- a/internal/controllers/products/delete_test.go
+++ b/internal/controllers/products/delete_test.go
@@ -30,7 +30,7 @@ func TestProducts_Delete(t *testing.T) {
 		expected expected
 	}{
 		{
-			name:    "204 - Product deleted successfully",
+			name:    "204 - When a valid product ID is provided for deletion",
 			id:      "1",
 			callErr: nil,
 			expected: expected{
@@ -39,7 +39,7 @@ func TestProducts_Delete(t *testing.T) {
 			},
 		},
 		{
-			name: "400 - Invalid ID format",
+			name: "400 - When passing a non numeric ID to the request",
 			id:   "invalid",
 			expected: expected{
 				calls:      0,
@@ -48,7 +48,7 @@ func TestProducts_Delete(t *testing.T) {
 			},
 		},
 		{
-			name: "400 - Negative ID not allowed",
+			name: "400 - When passing a negative ID to the request",
 			id:   "-1",
 			expected: expected{
 				calls:      0,
@@ -57,7 +57,7 @@ func TestProducts_Delete(t *testing.T) {
 			},
 		},
 		{
-			name:    "404 - Product not found",
+			name:    "404 - When trying to delete a product that does not exist",
 			id:      "10",
 			callErr: models.ErrProductNotFound,
 			expected: expected{
@@ -67,7 +67,7 @@ func TestProducts_Delete(t *testing.T) {
 			},
 		},
 		{
-			name:    "409 - Conflict: Cannot delete or update parent row",
+			name:    "409 - When attempting to delete a product linked to another resource",
 			id:      "1",
 			callErr: &mysql.MySQLError{Number: mysqlerr.CodeCannotDeleteOrUpdateParentRow},
 			expected: expected{

--- a/internal/controllers/products/delete_test.go
+++ b/internal/controllers/products/delete_test.go
@@ -1,0 +1,120 @@
+package productsctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-sql-driver/mysql"
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProducts_Delete(t *testing.T) {
+	type expected struct {
+		calls      int
+		statusCode int
+		message    string
+	}
+	tests := []struct {
+		name     string
+		id       string
+		callErr  error
+		expected expected
+	}{
+		{
+			name:    "204 - Product deleted successfully",
+			id:      "1",
+			callErr: nil,
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusNoContent,
+			},
+		},
+		{
+			name: "400 - Invalid ID format",
+			id:   "invalid",
+			expected: expected{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name: "400 - Negative ID not allowed",
+			id:   "-1",
+			expected: expected{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "Bad Request",
+			},
+		},
+		{
+			name:    "404 - Product not found",
+			id:      "10",
+			callErr: models.ErrProductNotFound,
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "product not found",
+			},
+		},
+		{
+			name:    "409 - Conflict: Cannot delete or update parent row",
+			id:      "1",
+			callErr: &mysql.MySQLError{Number: mysqlerr.CodeCannotDeleteOrUpdateParentRow},
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusConflict,
+				message:    "1451",
+			},
+		},
+		{
+			name:    "500 - Internal server error",
+			id:      "1",
+			callErr: errors.New("internal error"),
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewProductsServiceMock()
+			ctl := controllers.NewProductsController(sv)
+
+			r := chi.NewRouter()
+			r.Delete("/api/v1/products/{id}", ctl.Delete)
+			req := httptest.NewRequest(http.MethodDelete, "/api/v1/products/"+tt.id, nil)
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("Delete", mock.AnythingOfType("int")).Return(tt.callErr)
+			r.ServeHTTP(res, req)
+			ctl.Delete(res, req)
+
+			var decodedRes struct {
+				Message string `json:"message,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			// Assert
+			sv.AssertNumberOfCalls(t, "Delete", tt.expected.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected.statusCode, res.Code)
+			require.Contains(t, decodedRes.Message, tt.expected.message)
+
+		})
+	}
+}


### PR DESCRIPTION
### Motivação
A motivação por trás da implementação do endpoint de exclusão de produtos é assegurar que o sistema possa lidar eficazmente com a remoção de produtos, respeitando as regras de negócio estabelecidas.

### Solução proposta
Implementação de testes automatizados para o endpoint DELETE do recurso "products"

**Rotas:** `/api/v1/products/{id}`

Os testes incluem os seguintes cenários:

> **"204 - When a valid product ID is provided for deletion":** Verifica que a exclusão de um produto é realizada com sucesso quando um ID válido é fornecido.
> 
> **"400 - When passing a non numeric ID to the request":** Assegura que um erro 400 é retornado quando o ID fornecido não está em um formato válido.
> 
> **"400 - When passing a negative ID to the request":** Confirma que um erro 400 é retornado quando um ID negativo é fornecido.
> 
> **"404 - When trying to delete a product that does not exist":** Verifica que um erro 404 é retornado quando se tenta excluir um produto que não existe no sistema.
> 
> **"409 - When attempting to delete a product linked to a Seller ID":** Testa que um erro de conflito (409) é retornado quando a exclusão de um produto não pode ser realizada devido a restrições de integridade referencial ligadas ao Seller ID.
>
> **"500 - Internal server error":** Confirma que um erro interno do servidor (500) é retornado em situações onde a exclusão do produto resulta em uma falha no processamento


### Comentários
#165 