### PR TITLE
implementing tests for handler layer to delete  method

### DIFF
--- a/internal/controllers/warehouses/delete.go
+++ b/internal/controllers/warehouses/delete.go
@@ -1,11 +1,13 @@
 package warehousesctl
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-sql-driver/mysql"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
 	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
 	"github.com/maxwelbm/alkemy-g6/pkg/response"
 )
@@ -25,25 +27,36 @@ import (
 // @Router /api/v1/warehouses/{id} [delete]
 func (c *WarehouseDefault) Delete(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))
-	if err != nil || id < 1 {
+	if err != nil {
 		response.Error(w, http.StatusBadRequest, err.Error())
 		return
 	}
-
-	_, err = c.sv.GetByID(id)
-	if err != nil {
-		response.Error(w, http.StatusNotFound, err.Error())
+	// If the ID is less than 1, return a 400 Bad Request error
+	if id < 1 {
+		response.Error(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
 		return
 	}
 
 	err = c.sv.Delete(id)
+
 	if err != nil {
+		// Handle if section not found
+		if errors.Is(err, models.ErrWareHouseNotFound) {
+			response.Error(w, http.StatusNotFound, err.Error())
+			return
+		}
+		// Handle no changes made
+		if errors.Is(err, models.ErrorNoChangesMade) {
+			response.Error(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		// Handle MySQL conflict dependencies
 		if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == mysqlerr.CodeCannotDeleteOrUpdateParentRow {
 			response.Error(w, http.StatusConflict, err.Error())
 			return
 		}
-
-		response.Error(w, http.StatusUnprocessableEntity, err.Error())
+		// Handle other internal server errors
+		response.Error(w, http.StatusInternalServerError, err.Error())
 
 		return
 	}

--- a/internal/controllers/warehouses/delete_test.go
+++ b/internal/controllers/warehouses/delete_test.go
@@ -1,0 +1,123 @@
+package warehousesctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-sql-driver/mysql"
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	warehousesctl "github.com/maxwelbm/alkemy-g6/internal/controllers/warehouses"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWarehouses_Delete(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+	}
+	tests := []struct {
+		name    string
+		id      string
+		callErr error
+		wanted  wanted
+	}{
+		{
+			name:    "204 - When the warehouse is deleted successfully",
+			id:      "1",
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNoContent,
+			},
+		},
+		{
+			name:    "400 - When passing a negative id",
+			id:      "-1",
+			callErr: nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "Bad Request",
+			},
+		},
+		{
+			name:    "400 - When passing a non numeric id",
+			id:      "a",
+			callErr: nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name:    "404 - When the repository raises a WareHouseNotFound error",
+			id:      "100",
+			callErr: models.ErrWareHouseNotFound,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "warehouse not found",
+			},
+		},
+		{
+			name:    "409 - When the repository raises a CannotDeleteOrUpdateParentRow error",
+			id:      "1",
+			callErr: &mysql.MySQLError{Number: mysqlerr.CodeCannotDeleteOrUpdateParentRow},
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusConflict,
+				message:    "1451",
+			},
+		},
+		{
+			name:    "500 - When the repository returns an error",
+			id:      "1",
+			callErr: errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sv := service.NewWarehousesServiceMock()
+			ctl := controllers.NewWarehousesController(sv)
+
+			r := chi.NewRouter()
+			r.Delete("/api/v1/warehouses/{id}", ctl.Delete)
+			req := httptest.NewRequest(http.MethodDelete, "/api/v1/warehouses/"+tt.id, nil)
+			res := httptest.NewRecorder()
+
+			sv.On("Delete", mock.AnythingOfType("int")).Return(tt.callErr)
+			sv.On("Delete", mock.AnythingOfType("int")).Return(tt.callErr)
+			r.ServeHTTP(res, req)
+			ctl.Delete(res, req)
+
+			var decodedRes struct {
+				Message string                               `json:"message,omitempty"`
+				Data    []warehousesctl.WarehouseDataResJSON `json:"data,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			// Assert
+			sv.AssertNumberOfCalls(t, "Delete", tt.wanted.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+
+		})
+	}
+}

--- a/internal/repository/warehouses/delete.go
+++ b/internal/repository/warehouses/delete.go
@@ -3,22 +3,20 @@ package warehousesrp
 import "github.com/maxwelbm/alkemy-g6/internal/models"
 
 func (r *WarehouseRepository) Delete(id int) (err error) {
-	query := "DELETE FROM warehouses WHERE `id`=?"
-	result, err := r.db.Exec(query, id)
+	var exists bool
+	err = r.db.QueryRow("SELECT EXISTS(SELECT 1 FROM warehouses WHERE id = ?)", id).Scan(&exists)
 
 	if err != nil {
 		return
 	}
 
-	rowAffected, err := result.RowsAffected()
-	if err != nil {
-		return
-	}
-
-	if rowAffected == 0 {
+	if !exists {
 		err = models.ErrWareHouseNotFound
 		return
 	}
+
+	query := "DELETE FROM warehouses WHERE id = ?"
+	_, err = r.db.Exec(query, id)
 
 	return
 }

--- a/internal/service/warehouses_mock.go
+++ b/internal/service/warehouses_mock.go
@@ -35,5 +35,5 @@ func (m *WarehousesServiceMock) Update(id int, warehouse models.WarehouseDTO) (w
 
 func (m *WarehousesServiceMock) Delete(id int) (err error) {
 	args := m.Called(id)
-	return args.Error(1)
+	return args.Error(0)
 }


### PR DESCRIPTION
## Motivação
Implementar testes para o método de DELETE do recurso Warehouse.

## Solução proposta
Esta PR trata da implementação de testes para o método DELETE:

DELETE /api/v1/warehouses/{id}: Testar a requisição de deleção de uma warehouse. 

## Como testar
go test -v ./internal/controllers/warehouses/delete_test.go

## Link p/ história
https://github.com/maxwelbm/alkemy-g6/issues/132