### PR TITLE
Feat/warehouses patch controller tests

### DIFF
--- a/internal/controllers/warehouses/update.go
+++ b/internal/controllers/warehouses/update.go
@@ -38,12 +38,17 @@ func (c *WarehouseDefault) Update(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// If the ID is less than 1, return a 400 Bad Request error
+	if id < 1 {
+		response.Error(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+		return
+	}
 
 	var warehouseJSON WarehouseReqJSON
 	err = json.NewDecoder(r.Body).Decode(&warehouseJSON)
 
 	if err != nil {
-		response.JSON(w, http.StatusBadRequest, err.Error())
+		response.Error(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/internal/controllers/warehouses/update.go
+++ b/internal/controllers/warehouses/update.go
@@ -68,8 +68,8 @@ func (c *WarehouseDefault) Update(w http.ResponseWriter, r *http.Request) {
 
 	resWarehouse, err := c.sv.Update(id, warehouse)
 	if err != nil {
-		if errors.Is(err, models.ErrWareHouseCodeExist) {
-			response.Error(w, http.StatusConflict, err.Error())
+		if errors.Is(err, models.ErrWareHouseNotFound) {
+			response.Error(w, http.StatusNotFound, err.Error())
 			return
 		}
 

--- a/internal/controllers/warehouses/update_test.go
+++ b/internal/controllers/warehouses/update_test.go
@@ -1,0 +1,170 @@
+package warehousesctl_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	warehousesctl "github.com/maxwelbm/alkemy-g6/internal/controllers/warehouses"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWarehouses_Update(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+		warehouse  models.Warehouse
+	}
+	tests := []struct {
+		name          string
+		id            string
+		warehouseJSON string
+		callErr       error
+		wanted        wanted
+	}{
+		{
+			name: "200 - When the warehouse is updated successfully with all fields",
+			id:   "1",
+			warehouseJSON: `{
+				"address":"123 Main St",
+				"telephone": "555-1234", 
+				"warehouse_code": "WH001", 
+				"minimum_capacity":100, 
+				"minimum_temperature":-10
+			}`,
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+				message:    "OK",
+				warehouse: models.Warehouse{
+					ID:                 1,
+					Address:            "123 Main St",
+					Telephone:          "555-1234",
+					WarehouseCode:      "WH001",
+					MinimumCapacity:    100,
+					MinimumTemperature: -10,
+				},
+			},
+		},
+		// {
+		// 	name: "400 - When passing a body with invalid json",
+		// 	warehouseJSON: `{
+		// 		"address":"123 Main St",
+		// 		"telephone": "555-1234",
+		// 		"warehouse_code": "WH001",
+		// 		"minimum_capacity":"100",
+		// 		"minimum_temperature":-10
+		// 	}`,
+		// 	callErr: nil,
+		// 	wanted: wanted{
+		// 		statusCode: http.StatusBadRequest,
+		// 		message:    "json: cannot unmarshal",
+		// 	},
+		// },
+		// {
+		// 	name: "409 - When the repository raises a DuplicateEntry error",
+		// 	warehouseJSON: `{
+		// 		"address":"123 Main St",
+		// 		"telephone": "555-1234",
+		// 		"warehouse_code": "WH001",
+		// 		"minimum_capacity":100,
+		// 		"minimum_temperature":-10
+		// 	}`,
+		// 	callErr: &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
+		// 	wanted: wanted{
+		// 		calls:      1,
+		// 		statusCode: http.StatusConflict,
+		// 		message:    "1062",
+		// 		warehouse:  models.Warehouse{},
+		// 	},
+		// },
+		// {
+		// 	name: "422 - When passing a body with a valid json but missing parameters",
+		// 	warehouseJSON: `{
+		// 		"address":"123 Main St",
+		// 		"telephone": "555-1234",
+		// 		"warehouse_code": "WH001",
+		// 		"minimum_temperature":-10
+		// 	}`,
+		// 	callErr: nil,
+		// 	wanted: wanted{
+		// 		statusCode: http.StatusUnprocessableEntity,
+		// 		message:    "error: the minimum_capacity field cannot be nil",
+		// 	},
+		// },
+		// {
+		// 	name: "422 - When passing a body with a valid json but empty parameters",
+		// 	warehouseJSON: `{
+		// 		"address":"123 Main St",
+		// 		"telephone": "555-1234",
+		// 		"warehouse_code": "",
+		// 		"minimum_capacity":100,
+		// 		"minimum_temperature":-10
+		// 	}`,
+		// 	callErr: nil,
+		// 	wanted: wanted{
+		// 		statusCode: http.StatusUnprocessableEntity,
+		// 		message:    "error: the warehouse_code field cannot be empty",
+		// 	},
+		// },
+		// {
+		// 	name: "500 - When the repository returns an unexpected error",
+		// 	warehouseJSON: `{
+		// 		"address":"123 Main St",
+		// 		"telephone": "555-1234",
+		// 		"warehouse_code": "WH001",
+		// 		"minimum_capacity":100,
+		// 		"minimum_temperature":-10
+		// 	}`,
+		// 	callErr: errors.New("internal error"),
+		// 	wanted: wanted{
+		// 		calls:      1,
+		// 		statusCode: http.StatusInternalServerError,
+		// 		message:    "internal error",
+		// 		warehouse:  models.Warehouse{},
+		// 	},
+		// },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sv := service.NewWarehousesServiceMock()
+			ctl := controllers.NewWarehousesController(sv)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/warehouses/", strings.NewReader(tt.warehouseJSON))
+			res := httptest.NewRecorder()
+
+			sv.On("Create", mock.AnythingOfType("models.WarehouseDTO")).Return(tt.wanted.warehouse, tt.callErr)
+			ctl.Create(res, req)
+
+			// Assert
+			var decodedRes struct {
+				Message string                             `json:"message,omitempty"`
+				Data    warehousesctl.WarehouseDataResJSON `json:"data,omitempty"`
+			}
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&decodedRes))
+
+			sv.AssertNumberOfCalls(t, "Create", tt.wanted.calls)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+			if tt.wanted.statusCode == http.StatusCreated {
+				require.Equal(t, tt.wanted.warehouse.ID, decodedRes.Data.ID)
+				require.Equal(t, tt.wanted.warehouse.Address, decodedRes.Data.Address)
+				require.Equal(t, tt.wanted.warehouse.Telephone, decodedRes.Data.Telephone)
+				require.Equal(t, tt.wanted.warehouse.WarehouseCode, decodedRes.Data.WarehouseCode)
+				require.Equal(t, tt.wanted.warehouse.MinimumCapacity, decodedRes.Data.MinimumCapacity)
+				require.Equal(t, tt.wanted.warehouse.MinimumTemperature, decodedRes.Data.MinimumTemperature)
+			}
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+
+		})
+	}
+}

--- a/internal/controllers/warehouses/update_test.go
+++ b/internal/controllers/warehouses/update_test.go
@@ -2,15 +2,19 @@ package warehousesctl_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/go-sql-driver/mysql"
 	"github.com/maxwelbm/alkemy-g6/internal/controllers"
 	warehousesctl "github.com/maxwelbm/alkemy-g6/internal/controllers/warehouses"
 	"github.com/maxwelbm/alkemy-g6/internal/models"
 	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -54,84 +58,144 @@ func TestWarehouses_Update(t *testing.T) {
 				},
 			},
 		},
-		// {
-		// 	name: "400 - When passing a body with invalid json",
-		// 	warehouseJSON: `{
-		// 		"address":"123 Main St",
-		// 		"telephone": "555-1234",
-		// 		"warehouse_code": "WH001",
-		// 		"minimum_capacity":"100",
-		// 		"minimum_temperature":-10
-		// 	}`,
-		// 	callErr: nil,
-		// 	wanted: wanted{
-		// 		statusCode: http.StatusBadRequest,
-		// 		message:    "json: cannot unmarshal",
-		// 	},
-		// },
-		// {
-		// 	name: "409 - When the repository raises a DuplicateEntry error",
-		// 	warehouseJSON: `{
-		// 		"address":"123 Main St",
-		// 		"telephone": "555-1234",
-		// 		"warehouse_code": "WH001",
-		// 		"minimum_capacity":100,
-		// 		"minimum_temperature":-10
-		// 	}`,
-		// 	callErr: &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
-		// 	wanted: wanted{
-		// 		calls:      1,
-		// 		statusCode: http.StatusConflict,
-		// 		message:    "1062",
-		// 		warehouse:  models.Warehouse{},
-		// 	},
-		// },
-		// {
-		// 	name: "422 - When passing a body with a valid json but missing parameters",
-		// 	warehouseJSON: `{
-		// 		"address":"123 Main St",
-		// 		"telephone": "555-1234",
-		// 		"warehouse_code": "WH001",
-		// 		"minimum_temperature":-10
-		// 	}`,
-		// 	callErr: nil,
-		// 	wanted: wanted{
-		// 		statusCode: http.StatusUnprocessableEntity,
-		// 		message:    "error: the minimum_capacity field cannot be nil",
-		// 	},
-		// },
-		// {
-		// 	name: "422 - When passing a body with a valid json but empty parameters",
-		// 	warehouseJSON: `{
-		// 		"address":"123 Main St",
-		// 		"telephone": "555-1234",
-		// 		"warehouse_code": "",
-		// 		"minimum_capacity":100,
-		// 		"minimum_temperature":-10
-		// 	}`,
-		// 	callErr: nil,
-		// 	wanted: wanted{
-		// 		statusCode: http.StatusUnprocessableEntity,
-		// 		message:    "error: the warehouse_code field cannot be empty",
-		// 	},
-		// },
-		// {
-		// 	name: "500 - When the repository returns an unexpected error",
-		// 	warehouseJSON: `{
-		// 		"address":"123 Main St",
-		// 		"telephone": "555-1234",
-		// 		"warehouse_code": "WH001",
-		// 		"minimum_capacity":100,
-		// 		"minimum_temperature":-10
-		// 	}`,
-		// 	callErr: errors.New("internal error"),
-		// 	wanted: wanted{
-		// 		calls:      1,
-		// 		statusCode: http.StatusInternalServerError,
-		// 		message:    "internal error",
-		// 		warehouse:  models.Warehouse{},
-		// 	},
-		// },
+		{
+			name: "200 - When the warehouse is updated successfully with missing fields",
+			id:   "1",
+			warehouseJSON: `{
+				"address":"123 Main St",
+				"warehouse_code": "WH001", 
+				"minimum_capacity":100, 
+				"minimum_temperature":-10
+			}`,
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+				message:    "OK",
+				warehouse: models.Warehouse{
+					ID:                 1,
+					Address:            "123 Main St",
+					WarehouseCode:      "WH001",
+					MinimumCapacity:    100,
+					MinimumTemperature: -10,
+				},
+			},
+		},
+		{
+			name: "400 - When passing a negative id",
+			id:   "-1",
+			warehouseJSON: `{
+				"address":"123 Main St",
+				"telephone": "555-1234",
+				"warehouse_code": "WH001",
+				"minimum_capacity":100,
+				"minimum_temperature":-10
+			}`,
+			callErr: nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "Bad Request",
+			},
+		},
+		{
+			name: "400 - When passing a non numeric id",
+			id:   "a",
+			warehouseJSON: `{
+				"address":"123 Main St",
+				"telephone": "555-1234",
+				"warehouse_code": "WH001",
+				"minimum_capacity":100,
+				"minimum_temperature":-10
+			}`,
+			callErr: nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name: "400 - When passing a body with invalid json",
+			id:   "1",
+			warehouseJSON: `{
+				"address":"123 Main St",
+				"telephone": "555-1234",
+				"warehouse_code": "WH001",
+				"minimum_capacity":"100",
+				"minimum_temperature":-10
+			}`,
+			callErr: nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "json: cannot unmarshal",
+			},
+		},
+		{
+			name: "404 - When the repository raises a WareHouseNotFound error",
+			id:   "50",
+			warehouseJSON: `{
+				"address":"123 Main St",
+				"telephone": "555-1234", 
+				"warehouse_code": "WH001", 
+				"minimum_capacity":100, 
+				"minimum_temperature":-10
+			}`,
+			callErr: models.ErrWareHouseNotFound,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "warehouse not found",
+			},
+		},
+		{
+			name: "409 - When the repository raises a DuplicateEntry error",
+			id:   "1",
+			warehouseJSON: `{
+				"address":"123 Main St",
+				"telephone": "555-1234",
+				"warehouse_code": "WH001",
+				"minimum_capacity":100,
+				"minimum_temperature":-10
+			}`,
+			callErr: &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusConflict,
+				message:    "1062",
+			},
+		},
+		{
+			name: "422 - When passing a body with a valid json but empty parameters",
+			id:   "1",
+			warehouseJSON: `{
+				"address":"123 Main St",
+				"telephone": "555-1234",
+				"warehouse_code": "",
+				"minimum_capacity":100,
+				"minimum_temperature":-10
+			}`,
+			callErr: nil,
+			wanted: wanted{
+				statusCode: http.StatusUnprocessableEntity,
+				message:    "error: the warehouse_code field cannot be empty",
+			},
+		},
+		{
+			name: "500 - When the repository returns an unexpected error",
+			id:   "1",
+			warehouseJSON: `{
+				"address":"123 Main St",
+				"telephone": "555-1234",
+				"warehouse_code": "WH001",
+				"minimum_capacity":100,
+				"minimum_temperature":-10
+			}`,
+			callErr: errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -139,11 +203,18 @@ func TestWarehouses_Update(t *testing.T) {
 			sv := service.NewWarehousesServiceMock()
 			ctl := controllers.NewWarehousesController(sv)
 
-			req := httptest.NewRequest(http.MethodPost, "/api/v1/warehouses/", strings.NewReader(tt.warehouseJSON))
+			r := chi.NewRouter()
+			r.Patch("/api/v1/warehouses/{id}", ctl.Update)
+
+			req := httptest.NewRequest(http.MethodPatch, "/api/v1/warehouses/"+tt.id, strings.NewReader(tt.warehouseJSON))
 			res := httptest.NewRecorder()
 
-			sv.On("Create", mock.AnythingOfType("models.WarehouseDTO")).Return(tt.wanted.warehouse, tt.callErr)
-			ctl.Create(res, req)
+			sv.On(
+				"Update",
+				mock.AnythingOfType("int"),
+				mock.AnythingOfType("models.WarehouseDTO"),
+			).Return(tt.wanted.warehouse, tt.callErr)
+			r.ServeHTTP(res, req)
 
 			// Assert
 			var decodedRes struct {
@@ -152,10 +223,10 @@ func TestWarehouses_Update(t *testing.T) {
 			}
 			require.NoError(t, json.NewDecoder(res.Body).Decode(&decodedRes))
 
-			sv.AssertNumberOfCalls(t, "Create", tt.wanted.calls)
+			sv.AssertNumberOfCalls(t, "Update", tt.wanted.calls)
 			require.Equal(t, tt.wanted.statusCode, res.Code)
 			require.Contains(t, decodedRes.Message, tt.wanted.message)
-			if tt.wanted.statusCode == http.StatusCreated {
+			if tt.callErr != nil {
 				require.Equal(t, tt.wanted.warehouse.ID, decodedRes.Data.ID)
 				require.Equal(t, tt.wanted.warehouse.Address, decodedRes.Data.Address)
 				require.Equal(t, tt.wanted.warehouse.Telephone, decodedRes.Data.Telephone)
@@ -163,8 +234,6 @@ func TestWarehouses_Update(t *testing.T) {
 				require.Equal(t, tt.wanted.warehouse.MinimumCapacity, decodedRes.Data.MinimumCapacity)
 				require.Equal(t, tt.wanted.warehouse.MinimumTemperature, decodedRes.Data.MinimumTemperature)
 			}
-			require.Contains(t, decodedRes.Message, tt.wanted.message)
-
 		})
 	}
 }


### PR DESCRIPTION
## Motivação
Implementar testes para o método de PATCH do recurso Warehouse.

## Solução proposta
Esta PR trata da implementação de testes para o método PATCH:

PATCH /api/v1/warehouses/{id}: Testar a requisição de atualização de uma warehouse. 

## Como testar
go test -v ./internal/controllers/warehouses/update_test.go

## Link p/ história
https://github.com/maxwelbm/alkemy-g6/issues/132