### PR TITLE
Test controller patch products

### DIFF
--- a/internal/controllers/products/update_test.go
+++ b/internal/controllers/products/update_test.go
@@ -1,0 +1,286 @@
+package productsctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-sql-driver/mysql"
+	productsctl "github.com/maxwelbm/alkemy-g6/internal/controllers/products"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProducts_Update(t *testing.T) {
+	type expected struct {
+		calls      int
+		statusCode int
+		message    string
+		product    models.Product
+	}
+	tests := []struct {
+		name        string
+		id          string
+		productJSON string
+		callErr     error
+		expected    expected
+	}{
+		{
+			name: "200 - Successfully update product with all fields",
+			id:   "1",
+			productJSON: `
+			{
+				"product_code": "P011",
+				"description": "Product 11",
+				"height": 10,
+				"length": 20,
+				"width": 30,
+				"net_weight": 40,
+				"expiration_rate": 1,
+				"freezing_rate": 2,
+				"recommended_freezing_temp": -10,
+				"product_type_id": 1,
+				"seller_id": 1
+			}`,
+			callErr: nil,
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusOK,
+				message:    "Updated",
+				product: models.Product{
+					ProductCode:    "P011",
+					Description:    "Product 11",
+					Height:         10,
+					Length:         20,
+					Width:          30,
+					NetWeight:      40,
+					ExpirationRate: 1,
+					FreezingRate:   2,
+					RecomFreezTemp: -10,
+					ProductTypeID:  1,
+					SellerID:       1,
+				},
+			},
+		},
+		{
+			name: "200 - When updating product with missing fields",
+			id:   "1",
+			productJSON: `
+			{
+				"recommended_freezing_temp": -10,
+				"product_type_id": 1,
+				"seller_id": 1
+			}`,
+			callErr: nil,
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusOK,
+				message:    "Updated",
+				product: models.Product{
+					RecomFreezTemp: -10,
+					ProductTypeID:  1,
+					SellerID:       1,
+				},
+			},
+		},
+		{
+			name: "400 - When providing a non-numeric ID",
+			id:   "abc",
+			productJSON: `
+			{
+				"recommended_freezing_temp": -10,
+				"product_type_id": 1,
+				"seller_id": 1
+			}`,
+			callErr: nil,
+			expected: expected{
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name: "400 - When providing a negative ID",
+			id:   "-1",
+			productJSON: `
+			{
+				"recommended_freezing_temp": -10,
+				"product_type_id": 1,
+				"seller_id": 1
+			}`,
+			callErr: nil,
+			expected: expected{
+				statusCode: http.StatusBadRequest,
+				message:    "Bad Request",
+			},
+		},
+		{
+			name: "400 - When passing a body with invalid JSON",
+			id:   "1",
+			productJSON: `
+			{
+				"recommended_freezing_temp": "",
+				"product_type_id": "",
+				"seller_id": ""
+			}`,
+			callErr: nil,
+			expected: expected{
+				statusCode: http.StatusBadRequest,
+				message:    "json: cannot unmarshal",
+			},
+		},
+		{
+			name: "404 - When trying to update a product that does not exist",
+			id:   "999",
+			productJSON: `
+			{
+				"recommended_freezing_temp": -10,
+				"product_type_id": 1,
+				"seller_id": 1
+			}`,
+			callErr: models.ErrProductNotFound,
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "product not found",
+			},
+		},
+		{
+			name: "409 - When attempting to update to an existing product code",
+			id:   "1",
+			productJSON: `
+			{
+				"product_code": "P001",
+				"recommended_freezing_temp": -10,
+				"product_type_id": 1,
+				"seller_id": 1
+			}`,
+			callErr: models.ErrProductCodeExist,
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusConflict,
+				message:    "product code already exist",
+			},
+		},
+		{
+			name: "409 - When the repository raises a DuplicateEntry error",
+			id:   "1",
+			productJSON: `
+			{
+				"product_code": "P001",
+				"recommended_freezing_temp": -10,
+				"product_type_id": 1,
+				"seller_id": 1
+			}`,
+			callErr: &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusConflict,
+				message:    "1062",
+			},
+		},
+		{
+			name: "409 - When trying to update with an invalid Seller ID",
+			id:   "1",
+			productJSON: `
+			{
+				"product_code": "P0221",
+				"recommended_freezing_temp": -10,
+				"product_type_id": 1,
+				"seller_id": 11111
+			}`,
+			callErr: &mysql.MySQLError{Number: mysqlerr.CodeCannotAddOrUpdateChildRow},
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusConflict,
+				message:    "1452",
+			},
+		},
+		{
+			name: "422 - When passing a body with empty fields",
+			id:   "1",
+			productJSON: `
+			{
+				"product_code": "P0221",
+				"description": "",
+				"recommended_freezing_temp": -10,
+				"product_type_id": 1,
+				"seller_id": 11111
+			}`,
+			callErr: nil,
+			expected: expected{
+				statusCode: http.StatusUnprocessableEntity,
+				message:    "error: attribute Description cannot be empty",
+			},
+		},
+		{
+			name: "500 - When the repository returns an error during update",
+			id:   "1",
+			productJSON: `
+			{
+				"product_code": "P0221",
+				"recommended_freezing_temp": -10,
+				"product_type_id": 1,
+				"seller_id": 11111
+			}`,
+			callErr: errors.New("internal error"),
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			product := tt.expected.product
+			// Arrange
+			sv := service.NewProductsServiceMock()
+			ctl := productsctl.NewProductsController(sv)
+
+			r := chi.NewRouter()
+			r.Patch("/api/v1/products/{id}", ctl.Update)
+
+			req := httptest.NewRequest(http.MethodPatch, "/api/v1/products/"+tt.id, strings.NewReader(tt.productJSON))
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("Update", mock.AnythingOfType("int"), mock.AnythingOfType("models.ProductDTO")).Return(product, tt.callErr)
+			r.ServeHTTP(res, req)
+
+			// Assert
+			var decodedRes struct {
+				Message string                      `json:"message,omitempty"`
+				Data    productsctl.ProductFullJSON `json:"data,omitempty"`
+			}
+
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+			require.NoError(t, err)
+
+			sv.AssertNumberOfCalls(t, "Update", tt.expected.calls)
+			require.Equal(t, tt.expected.statusCode, res.Code)
+			if tt.callErr != nil {
+				require.Equal(t, product.ID, decodedRes.Data.ID)
+				require.Equal(t, product.ProductCode, decodedRes.Data.ProductCode)
+				require.Equal(t, product.Description, decodedRes.Data.Description)
+				require.Equal(t, product.Height, decodedRes.Data.Height)
+				require.Equal(t, product.Length, decodedRes.Data.Length)
+				require.Equal(t, product.Width, decodedRes.Data.Width)
+				require.Equal(t, product.NetWeight, decodedRes.Data.NetWeight)
+				require.Equal(t, product.ExpirationRate, decodedRes.Data.ExpirationRate)
+				require.Equal(t, product.FreezingRate, decodedRes.Data.FreezingRate)
+				require.Equal(t, product.RecomFreezTemp, decodedRes.Data.RecomFreezTemp)
+				require.Equal(t, product.ProductTypeID, decodedRes.Data.ProductTypeID)
+				require.Equal(t, product.SellerID, decodedRes.Data.SellerID)
+			}
+			require.Contains(t, decodedRes.Message, tt.expected.message)
+		})
+	}
+}

--- a/internal/models/products.go
+++ b/internal/models/products.go
@@ -4,6 +4,7 @@ import "errors"
 
 var (
 	ErrProductNotFound      = errors.New("product not found")
+	ErrProductCodeExist     = errors.New("product code already exist")
 	ErrReportRecordNotFound = errors.New("product report record not found")
 )
 

--- a/internal/repository/products/update.go
+++ b/internal/repository/products/update.go
@@ -5,9 +5,19 @@ import (
 )
 
 func (p *Products) Update(id int, prod models.ProductDTO) (updatedProd models.Product, err error) {
-	if prod.ProductCode != "" {
-		var exists bool
+	var exists bool
 
+	if err = p.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM products WHERE `id`=?)", id).Scan(&exists); err != nil {
+		return updatedProd, err
+	}
+
+	if !exists {
+		err = models.ErrProductNotFound
+		return updatedProd, err
+	}
+
+	if prod.ProductCode != "" {
+		exists = false
 		query := "SELECT EXISTS(SELECT 1 FROM products WHERE `product_code`=?)"
 		err = p.DB.QueryRow(query, prod.ProductCode).Scan(&exists)
 
@@ -15,10 +25,12 @@ func (p *Products) Update(id int, prod models.ProductDTO) (updatedProd models.Pr
 			return updatedProd, err
 		}
 
-		if !exists {
-			err = models.ErrProductNotFound
+		if exists {
+			err = models.ErrProductCodeExist
 			return updatedProd, err
 		}
+
+		updatedProd.ProductCode = prod.ProductCode
 	}
 
 	query := `UPDATE products SET 
@@ -36,7 +48,7 @@ func (p *Products) Update(id int, prod models.ProductDTO) (updatedProd models.Pr
 			WHERE id = ?`
 
 	// Execute the update query
-	res, err := p.DB.Exec(query,
+	_, err = p.DB.Exec(query,
 		prod.ProductCode,
 		prod.Description,
 		prod.Height,
@@ -51,18 +63,6 @@ func (p *Products) Update(id int, prod models.ProductDTO) (updatedProd models.Pr
 		id)
 
 	if err != nil {
-		return updatedProd, err
-	}
-
-	// Check how many rows were affected
-	rowsAffected, err := res.RowsAffected()
-	if err != nil {
-		return updatedProd, err
-	}
-
-	// Check if the update affected any rows
-	if rowsAffected == 0 {
-		err = models.ErrProductNotFound
 		return updatedProd, err
 	}
 


### PR DESCRIPTION
### Motivação
A motivação por trás da implementação do endpoint de atualização de produtos (PATCH) é garantir que o sistema possa lidar eficientemente com as alterações nas informações dos produtos.

### Solução proposta
Implementação de testes automatizados para o endpoint PATCH do recurso "products".

**Rotas:**
`/api/v1/products/{id}`

Os testes incluem os seguintes cenários:

> 
> **"200 - Successfully update product with all fields":** Verifica que a atualização de um produto é realizada com sucesso quando todos os campos necessários são fornecidos corretamente.
> 
> **"200 - When updating product with missing fields":** Assegura que é possível atualizar um produto mesmo que alguns campos não sejam fornecidos, respeitando a flexibilidade das atualizações.
> 
> **"400 - When providing a non-numeric ID":** Garante que um erro 400 é retornado quando o ID fornecido não está no formato numérico esperado.
> 
> **"400 - When providing a negative ID":** Confirma que um erro 400 é retornado quando um ID negativo é passado, o que não é permitido.
> 
> **"400 - When passing a body with invalid JSON":** Testa que um erro 400 é retornado ao fornecer um corpo de solicitação que não contém um JSON válido.
> 
> **"404 - When trying to update a product that does not exist":** Verifica que um erro 404 é retornado quando se tenta atualizar um produto que não existe no sistema.
> 
> **"409 - When attempting to update to an existing product code":** Assegura que um erro de conflito (409) é retornado ao tentar atualizar um produto com um código que já está em uso por outro produto.
> 
> **"409 - When the repository raises a DuplicateEntry error":** Testa que um erro de conflito (409) é retornado quando a operação de atualização gera uma falha devido a uma entrada duplicada.
> 
> **"409 - When trying to update with an invalid Seller ID":** Garante que um erro de conflito é retornado ao tentar atualizar o produto com um ID de vendedor que não existe.
> 
> **"422 - When passing a body with empty fields":** Confirma que um erro 422 é retornado quando a solicitação contém campos vazios que não podem ser deixados em branco.
> 
> **"500 - When the repository returns an error during update":** Verifica que um erro interno do servidor (500) é retornado quando ocorre uma falha no processamento no repositório durante a atualização do produto.

### Comentários
#168 