### PR TITLE
Feat/localities test endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,24 +19,13 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-chi/chi/v5 v5.2.0 // indirect
+	github.com/go-chi/chi/v5 v5.2.0
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
-	github.com/stretchr/testify v1.10.0
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/swaggo/files v1.0.1 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-chi/chi v1.5.5 h1:vOB/HbEMt9QqBqErz07QehcOKHaWFtuj87tTDVz2qXE=
-github.com/go-chi/chi v1.5.5/go.mod h1:C9JqLr3tIYjDOZpzn+BCuxY8z8vmca43EeMgyZt7irw=
 github.com/go-chi/chi/v5 v5.2.0 h1:Aj1EtB0qR2Rdo2dG4O94RIU35w2lvQSj6BRA4+qwFL0=
 github.com/go-chi/chi/v5 v5.2.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=
@@ -34,10 +32,7 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/swaggo/files v1.0.1 h1:J1bVJ4XHZNq0I46UU90611i9/YzdrF7x92oX1ig5IdE=
 github.com/swaggo/files v1.0.1/go.mod h1:0qXmMNH6sXNf+73t65aKeB+ApmgxdnkQzVTAj2uaMUg=

--- a/internal/controllers/employees/get_all.go
+++ b/internal/controllers/employees/get_all.go
@@ -14,7 +14,7 @@ import (
 // @Description Fetches all employees from the database and returns them as JSON.
 // @Tags employees
 // @Produce json
-// @Success 200 {object} EmployeesFinalJSON "OK - The employees were successfully retrieved"
+// @Success 200 {object} EmployeesResJSON "OK - The employees were successfully retrieved"
 // @Failure 500 {object} response.ErrorResponse "Internal Server Error - An unexpected error occurred during the retrieval process"
 // @Router /api/v1/employees [get]
 func (c *EmployeesController) GetAll(w http.ResponseWriter, r *http.Request) {

--- a/internal/controllers/localities/create.go
+++ b/internal/controllers/localities/create.go
@@ -12,31 +12,43 @@ import (
 )
 
 type NewLocalityJSON struct {
-	LocalityName *string `json:"locality_name"`
-	ProvinceName *string `json:"province_name"`
-	CountryName  *string `json:"country_name"`
+	LocalityName *string `json:"locality_name,omitempty"`
+	ProvinceName *string `json:"province_name,omitempty"`
+	CountryName  *string `json:"country_name,omitempty"`
 }
 
 func (j *NewLocalityJSON) validate() (err error) {
 	var locErrs []string
 
 	if j.LocalityName == nil {
-		locErrs = append(locErrs, "error: locality_name is required")
+		locErrs = append(locErrs, "error: locality_name cannot be nil")
+	}
+
+	if j.LocalityName != nil && *j.LocalityName == "" {
+		locErrs = append(locErrs, "error: locality_name cannot be empty")
 	}
 
 	if j.ProvinceName == nil {
-		locErrs = append(locErrs, "error: province_name is required")
+		locErrs = append(locErrs, "error: province_name cannot be nil")
+	}
+
+	if j.ProvinceName != nil && *j.ProvinceName == "" {
+		locErrs = append(locErrs, "error: province_name cannot be empty")
 	}
 
 	if j.CountryName == nil {
-		locErrs = append(locErrs, "error: country_name is required")
+		locErrs = append(locErrs, "error: country_name cannot be nil")
+	}
+
+	if j.CountryName != nil && *j.CountryName == "" {
+		locErrs = append(locErrs, "error: country_name cannot be empty")
 	}
 
 	if len(locErrs) > 0 {
 		err = fmt.Errorf("validation errors: %v", locErrs)
 	}
 
-	return
+	return err
 }
 
 // Create handles the creation of a new locality.
@@ -57,7 +69,7 @@ func (ct *LocalitiesController) Create(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&locJSON)
 
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		response.Error(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -86,10 +98,18 @@ func (ct *LocalitiesController) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// builds json
+	var localityJSON = FullLocalitySON{
+		ID:           loc.ID,
+		LocalityName: loc.LocalityName,
+		ProvinceName: loc.ProvinceName,
+		CountryName:  loc.CountryName,
+	}
+
 	// response
 	data := LocalityResJSON{
 		Message: http.StatusText(http.StatusCreated),
-		Data:    loc,
+		Data:    localityJSON,
 	}
 	response.JSON(w, http.StatusCreated, data)
 }

--- a/internal/controllers/localities/create.go
+++ b/internal/controllers/localities/create.go
@@ -79,9 +79,9 @@ func (ct *LocalitiesController) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	// builds dto from json
 	locDTO := &models.LocalityDTO{
-		LocalityName: *locJSON.LocalityName,
-		ProvinceName: *locJSON.ProvinceName,
-		CountryName:  *locJSON.CountryName,
+		LocalityName: locJSON.LocalityName,
+		ProvinceName: locJSON.ProvinceName,
+		CountryName:  locJSON.CountryName,
 	}
 
 	// insert

--- a/internal/controllers/localities/create_test.go
+++ b/internal/controllers/localities/create_test.go
@@ -1,0 +1,130 @@
+package localitiesctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	localitiesctl "github.com/maxwelbm/alkemy-g6/internal/controllers/localities"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreate(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+		locality   models.Locality
+	}
+	tests := []struct {
+		name         string
+		localityJSON string
+		callErr      error
+		wanted       wanted
+	}{
+		{
+			name:         "201 - When the locality is created successfully",
+			localityJSON: `{"locality_name": "São Paulo", "province_name": "São Paulo", "country_name": "Brazil"}`,
+			callErr:      nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusCreated,
+				message:    "Created",
+				locality:   models.Locality{ID: 1, LocalityName: "São Paulo", ProvinceName: "São Paulo", CountryName: "Brazil"},
+			},
+		},
+		{
+			name:         "400 - When passing a body with invalid json",
+			localityJSON: `{"locality_name": 1, "province_name": 2, "country_name": 3}`,
+			callErr:      nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "json: cannot unmarshal",
+			},
+		},
+		{
+			name:         "409 - When the repository raises a DuplicateEntry error",
+			localityJSON: `{"locality_name": "São Paulo", "province_name": "São Paulo", "country_name": "Brazil"}`,
+			callErr:      &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusConflict,
+				message:    "1062",
+				locality:   models.Locality{},
+			},
+		},
+		{
+			name:         "422 - When passing a body with a valid json with missing parameters",
+			localityJSON: `{"province_name": "São Paulo", "country_name": "Brazil"}`,
+			callErr:      nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusUnprocessableEntity,
+				message:    "locality_name cannot be nil",
+			},
+		},
+		{
+			name:         "422 - When passing a body with a valid json with empty parameters",
+			localityJSON: `{"locality_name": "", "province_name": "São Paulo", "country_name": "Brazil"}`,
+			callErr:      nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusUnprocessableEntity,
+				message:    "locality_name cannot be empty",
+			},
+		},
+		{
+			name:         "500 - When the repository returns an unexpected error",
+			localityJSON: `{"locality_name": "São Paulo", "province_name": "São Paulo", "country_name": "Brazil"}`,
+			callErr:      errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+				locality:   models.Locality{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewLocalitiesServiceMock()
+			ctl := controllers.NewLocalityController(sv)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/localities", strings.NewReader(tt.localityJSON))
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("Create", mock.AnythingOfType("models.LocalityDTO")).Return(tt.wanted.locality, tt.callErr)
+			ctl.Create(res, req)
+
+			// Assert
+			var decodedRes struct {
+				Message string                        `json:"message,omitempty"`
+				Data    localitiesctl.FullLocalitySON `json:"data,omitempty"`
+			}
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&decodedRes))
+
+			sv.AssertNumberOfCalls(t, "Create", tt.wanted.calls)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+			if tt.wanted.statusCode == http.StatusCreated {
+				require.Equal(t, tt.wanted.locality.LocalityName, decodedRes.Data.LocalityName)
+				require.Equal(t, tt.wanted.locality.ProvinceName, decodedRes.Data.ProvinceName)
+				require.Equal(t, tt.wanted.locality.CountryName, decodedRes.Data.CountryName)
+			}
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/controllers/localities/create_test.go
+++ b/internal/controllers/localities/create_test.go
@@ -106,7 +106,14 @@ func TestCreate(t *testing.T) {
 			res := httptest.NewRecorder()
 
 			// Act
-			sv.On("Create", mock.AnythingOfType("models.LocalityDTO")).Return(tt.wanted.locality, tt.callErr)
+			sv.On("Create", mock.MatchedBy(func(dto models.LocalityDTO) bool {
+				if tt.callErr != nil {
+					return true
+				}
+				return (*dto.LocalityName == tt.wanted.locality.LocalityName &&
+					*dto.ProvinceName == tt.wanted.locality.ProvinceName &&
+					*dto.CountryName == tt.wanted.locality.CountryName)
+			})).Return(tt.wanted.locality, tt.callErr)
 			ctl.Create(res, req)
 
 			// Assert

--- a/internal/controllers/localities/localities_default.go
+++ b/internal/controllers/localities/localities_default.go
@@ -14,3 +14,10 @@ type LocalityResJSON struct {
 	Message string `json:"message,omitempty"`
 	Data    any    `json:"data,omitempty"`
 }
+
+type FullLocalitySON struct {
+	ID           int    `json:"id"`
+	LocalityName string `json:"locality_name"`
+	ProvinceName string `json:"province_name"`
+	CountryName  string `json:"country_name"`
+}

--- a/internal/controllers/localities/report_carries.go
+++ b/internal/controllers/localities/report_carries.go
@@ -9,7 +9,7 @@ import (
 	"github.com/maxwelbm/alkemy-g6/pkg/response"
 )
 
-type CarryReportJSON struct {
+type LocalityCarriesReportJSON struct {
 	ID           int    `json:"id"`
 	LocalityName string `json:"locality_name"`
 	CarriesCount int    `json:"carries_count"`
@@ -21,7 +21,7 @@ type CarryReportJSON struct {
 // @Tags localities
 // @Produce json
 // @Param id query int true "Carry ID"
-// @Success 200 {object} CarryReportJSON "OK"
+// @Success 200 {object} LocalityResJSON "OK"
 // @Failure 400 {object} response.ErrorResponse "Bad Request"
 // @Failure 404 {object} response.ErrorResponse "Not Found"
 // @Failure 500 {object} response.ErrorResponse "Internal Server Error"
@@ -61,10 +61,10 @@ func (ct *LocalitiesController) ReportCarries(w http.ResponseWriter, r *http.Req
 	}
 
 	// Populate the response JSON with the locality report data
-	data := make([]CarryReportJSON, 0, len(locs))
+	data := make([]LocalityCarriesReportJSON, 0, len(locs))
 
 	for _, loc := range locs {
-		locJSON := CarryReportJSON{
+		locJSON := LocalityCarriesReportJSON{
 			ID:           loc.ID,
 			LocalityName: loc.LocalityName,
 			CarriesCount: loc.CarriesCount,

--- a/internal/controllers/localities/report_carries_test.go
+++ b/internal/controllers/localities/report_carries_test.go
@@ -1,0 +1,145 @@
+package localitiesctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	localitiesctl "github.com/maxwelbm/alkemy-g6/internal/controllers/localities"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReportCarries(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+	}
+	tests := []struct {
+		name    string
+		id      string
+		reports []models.LocalityCarriesReport
+		callErr error
+		wanted  wanted
+	}{
+		{
+			name: "200 - When localities are registered in the database and no id is passed",
+			reports: []models.LocalityCarriesReport{
+				{ID: 1, LocalityName: "Locality 1", CarriesCount: 1},
+				{ID: 2, LocalityName: "Locality 2", CarriesCount: 2},
+				{ID: 3, LocalityName: "Locality 3", CarriesCount: 3},
+			},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name: "200 - When localities are registered in the database and a valid id is passed",
+			reports: []models.LocalityCarriesReport{
+				{ID: 2, LocalityName: "Locality 2", CarriesCount: 2},
+			},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name:    "200 - When no localities are registered in the database and no id is passed",
+			id:      "2",
+			reports: []models.LocalityCarriesReport{},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name:    "400 - When passing a non numeric id",
+			id:      "S2",
+			callErr: nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name:    "400 - When passing a negative id",
+			id:      "-1",
+			callErr: nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "Bad Request",
+			},
+		},
+		{
+			name:    "404 - When the respository raises a NotFound error",
+			id:      "999",
+			callErr: models.ErrLocalityNotFound,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "locality not found",
+			},
+		},
+		{
+			name:    "500 - When the repository returns an error",
+			reports: []models.LocalityCarriesReport{},
+			callErr: errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewLocalitiesServiceMock()
+			ctl := controllers.NewLocalityController(sv)
+
+			url := "/api/v1/localities/reportCarries"
+			if tt.id != "" {
+				url += fmt.Sprintf("?id=%s", tt.id)
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("ReportCarries", mock.AnythingOfType("int")).Return(tt.reports, tt.callErr)
+			ctl.ReportCarries(res, req)
+
+			var decodedRes struct {
+				Message string                                    `json:"message,omitempty"`
+				Data    []localitiesctl.LocalityCarriesReportJSON `json:"data,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			// Assert
+			sv.AssertNumberOfCalls(t, "ReportCarries", tt.wanted.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			if len(tt.reports) > 0 {
+				for i, locality := range tt.reports {
+					require.Equal(t, locality.ID, decodedRes.Data[i].ID)
+					require.Equal(t, locality.LocalityName, decodedRes.Data[i].LocalityName)
+					require.Equal(t, locality.CarriesCount, decodedRes.Data[i].CarriesCount)
+				}
+			}
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/controllers/localities/report_sellers.go
+++ b/internal/controllers/localities/report_sellers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/maxwelbm/alkemy-g6/pkg/response"
 )
 
-type LocalityReportJSON struct {
+type LocalitySellersReportJSON struct {
 	ID           int    `json:"id"`
 	LocalityName string `json:"locality_name"`
 	SellersCount int    `json:"sellers_count"`
@@ -61,10 +61,10 @@ func (ct *LocalitiesController) ReportSellers(w http.ResponseWriter, r *http.Req
 	}
 
 	// Populate the response JSON with the locality report data
-	data := make([]LocalityReportJSON, 0, len(locs))
+	data := make([]LocalitySellersReportJSON, 0, len(locs))
 
 	for _, loc := range locs {
-		locJSON := LocalityReportJSON{
+		locJSON := LocalitySellersReportJSON{
 			ID:           loc.ID,
 			LocalityName: loc.LocalityName,
 			SellersCount: loc.SellersCount,

--- a/internal/controllers/localities/report_sellers_test.go
+++ b/internal/controllers/localities/report_sellers_test.go
@@ -1,0 +1,145 @@
+package localitiesctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	localitiesctl "github.com/maxwelbm/alkemy-g6/internal/controllers/localities"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReportSellers(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+	}
+	tests := []struct {
+		name    string
+		id      string
+		reports []models.LocalitySellersReport
+		callErr error
+		wanted  wanted
+	}{
+		{
+			name: "200 - When localities are registered in the database and no id is passed",
+			reports: []models.LocalitySellersReport{
+				{ID: 1, LocalityName: "Locality 1", SellersCount: 1},
+				{ID: 2, LocalityName: "Locality 2", SellersCount: 2},
+				{ID: 3, LocalityName: "Locality 3", SellersCount: 3},
+			},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name: "200 - When localities are registered in the database and a valid id is passed",
+			reports: []models.LocalitySellersReport{
+				{ID: 2, LocalityName: "Locality 2", SellersCount: 2},
+			},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name:    "200 - When no localities are registered in the database and no id is passed",
+			id:      "2",
+			reports: []models.LocalitySellersReport{},
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name:    "400 - When passing a non numeric id",
+			id:      "S2",
+			callErr: nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "strconv.Atoi",
+			},
+		},
+		{
+			name:    "400 - When passing a negative id",
+			id:      "-1",
+			callErr: nil,
+			wanted: wanted{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "Bad Request",
+			},
+		},
+		{
+			name:    "404 - When the respository raises a NotFound error",
+			id:      "999",
+			callErr: models.ErrLocalityNotFound,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusNotFound,
+				message:    "locality not found",
+			},
+		},
+		{
+			name:    "500 - When the repository returns an error",
+			reports: []models.LocalitySellersReport{},
+			callErr: errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewLocalitiesServiceMock()
+			ctl := controllers.NewLocalityController(sv)
+
+			url := "/api/v1/localities/reportSellers"
+			if tt.id != "" {
+				url += fmt.Sprintf("?id=%s", tt.id)
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("ReportSellers", mock.AnythingOfType("int")).Return(tt.reports, tt.callErr)
+			ctl.ReportSellers(res, req)
+
+			var decodedRes struct {
+				Message string                                    `json:"message,omitempty"`
+				Data    []localitiesctl.LocalitySellersReportJSON `json:"data,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			// Assert
+			sv.AssertNumberOfCalls(t, "ReportSellers", tt.wanted.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			if len(tt.reports) > 0 {
+				for i, locality := range tt.reports {
+					require.Equal(t, locality.ID, decodedRes.Data[i].ID)
+					require.Equal(t, locality.LocalityName, decodedRes.Data[i].LocalityName)
+					require.Equal(t, locality.SellersCount, decodedRes.Data[i].SellersCount)
+				}
+			}
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/models/locality.go
+++ b/internal/models/locality.go
@@ -14,9 +14,9 @@ type Locality struct {
 }
 
 type LocalityDTO struct {
-	LocalityName string
-	ProvinceName string
-	CountryName  string
+	LocalityName *string
+	ProvinceName *string
+	CountryName  *string
 }
 
 type LocalitySellersReport struct {

--- a/internal/models/locality.go
+++ b/internal/models/locality.go
@@ -3,7 +3,7 @@ package models
 import "errors"
 
 var (
-	ErrLocalityNotFound = errors.New("Locality not found")
+	ErrLocalityNotFound = errors.New("locality not found")
 )
 
 type Locality struct {

--- a/internal/service/locality_default_mock.go
+++ b/internal/service/locality_default_mock.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/stretchr/testify/mock"
+)
+
+type LocalityDefaultMock struct {
+	mock.Mock
+}
+
+func NewLocalitiesServiceMock() *LocalityDefaultMock {
+	return &LocalityDefaultMock{}
+}
+
+func (l *LocalityDefaultMock) Create(locDTO models.LocalityDTO) (loc models.Locality, err error) {
+	args := l.Called(locDTO)
+	return args.Get(0).(models.Locality), args.Error(1)
+}
+
+func (l *LocalityDefaultMock) ReportSellers(id int) (reports []models.LocalitySellersReport, err error) {
+	args := l.Called(id)
+	return args.Get(0).([]models.LocalitySellersReport), args.Error(1)
+}
+
+func (l *LocalityDefaultMock) ReportCarries(id int) (reports []models.LocalityCarriesReport, err error) {
+	args := l.Called(id)
+	return args.Get(0).([]models.LocalityCarriesReport), args.Error(1)
+}

--- a/swagger/docs/docs.go
+++ b/swagger/docs/docs.go
@@ -351,7 +351,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK - The employees were successfully retrieved",
                         "schema": {
-                            "$ref": "#/definitions/employeesctl.EmployeesFinalJSON"
+                            "$ref": "#/definitions/employeesctl.EmployeesResJSON"
                         }
                     },
                     "500": {
@@ -455,7 +455,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "Employee not found",
+                        "description": "employee not found",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
@@ -499,13 +499,13 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid ID format",
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
                     },
                     "404": {
-                        "description": "Employee not found",
+                        "description": "employee not found",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
@@ -607,7 +607,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "Employee not found",
+                        "description": "employee not found",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
@@ -760,7 +760,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/localitiesctl.CarryReportJSON"
+                            "$ref": "#/definitions/localitiesctl.LocalityResJSON"
                         }
                     },
                     "400": {
@@ -863,7 +863,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Error ao decodificar JSON",
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
@@ -921,7 +921,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Error ao decodificar JSON",
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
@@ -2106,40 +2106,6 @@ const docTemplate = `{
                 }
             }
         },
-        "employeesctl.EmployeesAttributes": {
-            "type": "object",
-            "properties": {
-                "card_number_id": {
-                    "type": "string"
-                },
-                "count_reports": {
-                    "type": "integer"
-                },
-                "first_name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "last_name": {
-                    "type": "string"
-                },
-                "warehouse_id": {
-                    "type": "integer"
-                }
-            }
-        },
-        "employeesctl.EmployeesFinalJSON": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/employeesctl.EmployeesAttributes"
-                    }
-                }
-            }
-        },
         "employeesctl.EmployeesReqJSON": {
             "type": "object",
             "properties": {
@@ -2197,20 +2163,6 @@ const docTemplate = `{
             "properties": {
                 "data": {},
                 "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "localitiesctl.CarryReportJSON": {
-            "type": "object",
-            "properties": {
-                "carries_count": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "locality_name": {
                     "type": "string"
                 }
             }
@@ -2661,7 +2613,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
-	Host:             "localhost:8080",
+	Host:             "localhost:8000",
 	BasePath:         "/",
 	Schemes:          []string{},
 	Title:            "FrescosAPI",

--- a/swagger/docs/swagger.json
+++ b/swagger/docs/swagger.json
@@ -344,7 +344,7 @@
                     "200": {
                         "description": "OK - The employees were successfully retrieved",
                         "schema": {
-                            "$ref": "#/definitions/employeesctl.EmployeesFinalJSON"
+                            "$ref": "#/definitions/employeesctl.EmployeesResJSON"
                         }
                     },
                     "500": {
@@ -448,7 +448,7 @@
                         }
                     },
                     "404": {
-                        "description": "Employee not found",
+                        "description": "employee not found",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
@@ -492,13 +492,13 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid ID format",
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
                     },
                     "404": {
-                        "description": "Employee not found",
+                        "description": "employee not found",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
@@ -600,7 +600,7 @@
                         }
                     },
                     "404": {
-                        "description": "Employee not found",
+                        "description": "employee not found",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
@@ -753,7 +753,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/localitiesctl.CarryReportJSON"
+                            "$ref": "#/definitions/localitiesctl.LocalityResJSON"
                         }
                     },
                     "400": {
@@ -856,7 +856,7 @@
                         }
                     },
                     "400": {
-                        "description": "Error ao decodificar JSON",
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
@@ -914,7 +914,7 @@
                         }
                     },
                     "400": {
-                        "description": "Error ao decodificar JSON",
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/response.ErrorResponse"
                         }
@@ -2099,40 +2099,6 @@
                 }
             }
         },
-        "employeesctl.EmployeesAttributes": {
-            "type": "object",
-            "properties": {
-                "card_number_id": {
-                    "type": "string"
-                },
-                "count_reports": {
-                    "type": "integer"
-                },
-                "first_name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "last_name": {
-                    "type": "string"
-                },
-                "warehouse_id": {
-                    "type": "integer"
-                }
-            }
-        },
-        "employeesctl.EmployeesFinalJSON": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/employeesctl.EmployeesAttributes"
-                    }
-                }
-            }
-        },
         "employeesctl.EmployeesReqJSON": {
             "type": "object",
             "properties": {
@@ -2190,20 +2156,6 @@
             "properties": {
                 "data": {},
                 "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "localitiesctl.CarryReportJSON": {
-            "type": "object",
-            "properties": {
-                "carries_count": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "locality_name": {
                     "type": "string"
                 }
             }

--- a/swagger/docs/swagger.yaml
+++ b/swagger/docs/swagger.yaml
@@ -37,28 +37,6 @@ definitions:
       phone_number:
         type: string
     type: object
-  employeesctl.EmployeesAttributes:
-    properties:
-      card_number_id:
-        type: string
-      count_reports:
-        type: integer
-      first_name:
-        type: string
-      id:
-        type: integer
-      last_name:
-        type: string
-      warehouse_id:
-        type: integer
-    type: object
-  employeesctl.EmployeesFinalJSON:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/employeesctl.EmployeesAttributes'
-        type: array
-    type: object
   employeesctl.EmployeesReqJSON:
     properties:
       card_number_id:
@@ -97,15 +75,6 @@ definitions:
     properties:
       data: {}
       message:
-        type: string
-    type: object
-  localitiesctl.CarryReportJSON:
-    properties:
-      carries_count:
-        type: integer
-      id:
-        type: integer
-      locality_name:
         type: string
     type: object
   localitiesctl.LocalityResJSON:
@@ -624,7 +593,7 @@ paths:
         "200":
           description: OK - The employees were successfully retrieved
           schema:
-            $ref: '#/definitions/employeesctl.EmployeesFinalJSON'
+            $ref: '#/definitions/employeesctl.EmployeesResJSON'
         "500":
           description: Internal Server Error - An unexpected error occurred during
             the retrieval process
@@ -723,11 +692,11 @@ paths:
           schema:
             $ref: '#/definitions/employeesctl.EmployeesResJSON'
         "400":
-          description: Invalid ID format
+          description: Bad Request
           schema:
             $ref: '#/definitions/response.ErrorResponse'
         "404":
-          description: Employee not found
+          description: employee not found
           schema:
             $ref: '#/definitions/response.ErrorResponse'
       summary: Retrieve employee by ID
@@ -761,7 +730,7 @@ paths:
           schema:
             $ref: '#/definitions/response.ErrorResponse'
         "404":
-          description: Employee not found
+          description: employee not found
           schema:
             $ref: '#/definitions/response.ErrorResponse'
         "409":
@@ -798,7 +767,7 @@ paths:
           schema:
             $ref: '#/definitions/response.ErrorResponse'
         "404":
-          description: Employee not found
+          description: employee not found
           schema:
             $ref: '#/definitions/response.ErrorResponse'
         "500":
@@ -895,7 +864,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/localitiesctl.CarryReportJSON'
+            $ref: '#/definitions/localitiesctl.LocalityResJSON'
         "400":
           description: Bad Request
           schema:
@@ -962,7 +931,7 @@ paths:
           schema:
             $ref: '#/definitions/productbatchesctl.ProductBatchesResJSON'
         "400":
-          description: Error ao decodificar JSON
+          description: Bad Request
           schema:
             $ref: '#/definitions/response.ErrorResponse'
         "409":
@@ -1000,7 +969,7 @@ paths:
           schema:
             $ref: '#/definitions/productrecordsctl.ProductRecordResJSON'
         "400":
-          description: Error ao decodificar JSON
+          description: Bad Request
           schema:
             $ref: '#/definitions/response.ErrorResponse'
         "409":


### PR DESCRIPTION
## Motivação
<!-- Qual é a motivação por trás desta mudança? -->
Este PR aborda a primeira parte do requisito bonus descrito no card https://github.com/maxwelbm/alkemy-g6/issues/171
tratando de implementar testes unitarios nos controllers dos endpoints de locality:

- POST (create) `/api/v1/localities`
- GET `/api/v1/localities/reportCarries`
- GET `/api/v1/localities/reportSellers`

## Solução proposta
<!-- Quais mudanças esta PR propõe? -->
Implementação de testes unitários com mock do repository para os seguintes casos:
### Controllers/Localities

#### Create.go
- **201** - Quando a localidade é criada com sucesso
- **400** - Quando é passado um corpo com JSON inválido
- **409** - Quando o repositório gera um erro de entrada duplicada (DuplicateEntry)
- **422** - Quando é passado um corpo com JSON válido, mas com parâmetros nulos
- **422** - Quando é passado um corpo com JSON válido, mas com parâmetros vazios
- **500** - Quando o repositório retorna um erro inesperado

#### Report Carries.go
- **200** - Quando as localidades estão registradas no banco de dados e nenhum ID é passado
- **200** - Quando as localidades estão registradas no banco de dados e um ID válido é passado
- **200** - Quando nenhuma localidade está registrada no banco de dados e nenhum ID é passado
- **400** - Quando é passado um ID não numérico
- **400** - Quando é passado um ID negativo
- **404** - Quando o repositório gera um erro "Não Encontrado" (NotFound)
- **500** - Quando o repositório retorna um erro

#### Report Localities.go
- **200** - Quando as localidades estão registradas no banco de dados e nenhum ID é passado
- **200** - Quando as localidades estão registradas no banco de dados e um ID válido é passado
- **200** - Quando nenhuma localidade está registrada no banco de dados e nenhum ID é passado
- **400** - Quando é passado um ID não numérico
- **400** - Quando é passado um ID negativo
- **404** - Quando o repositório gera um erro "Não Encontrado" (NotFound)
- **500** - Quando o repositório retorna um erro

## Como testar
<!-- Descreva como testar as mudanças propostas. -->
Rode os testes unitários da camada de localities com:
```sh
make test ./internal/controllers/localities/*_test.go
```

## Link p/ história
<!-- Link para qualquer história ou issue relacionada (se aplicável). -->
https://github.com/maxwelbm/alkemy-g6/issues/171

## Comentário(s)
<!-- Comentários ou informações adicionais para os revisores. -->
Nesse PR também foi necessário atualizar alguns erros nos comentários da documentação do swagger, sendo assim as docs geradas pelo goswag foram atualizadas
Também foi necessário rodar `go mod tidy`para ajustar alguns problemas de dependencias, causando alterações nos arquivos `go.mod`e `go.sum`
