### PR TITLE
Feat/employees service tests

### DIFF
--- a/internal/controllers/employees/create_test.go
+++ b/internal/controllers/employees/create_test.go
@@ -96,7 +96,7 @@ func TestCreate(t *testing.T) {
 			},
 		},
 		{
-			name:         "500 - Internal Server Error when trying to retrieve the list of employees",
+			name:         "500 - Internal Server Error when trying to create an employee",
 			employeeJSON: `{"id": 1, "card_number_id":"3253","first_name":"Rick","last_name":"Grimes","warehouse_id":1}`,
 			callErr:      errors.New("internal error"),
 			expected: expected{

--- a/internal/controllers/employees/delete_test.go
+++ b/internal/controllers/employees/delete_test.go
@@ -79,7 +79,7 @@ func TestDelete(t *testing.T) {
 			},
 		},
 		{
-			name:    "500 - Internal Server Error when trying to retrieve the list of employees",
+			name:    "500 - Internal Server Error when trying to delete an employee",
 			id:      "1",
 			callErr: errors.New("internal error"),
 			expected: expected{

--- a/internal/controllers/employees/get_report_inbound_orders_test.go
+++ b/internal/controllers/employees/get_report_inbound_orders_test.go
@@ -20,7 +20,7 @@ func TestGetReportInboundOrders(t *testing.T) {
 		calls      int
 		statusCode int
 		message    string
-		reports    []models.EmployeeReportInboundDTO
+		reports    []models.EmployeeReportInbound
 	}
 	tests := []struct {
 		name     string
@@ -35,7 +35,7 @@ func TestGetReportInboundOrders(t *testing.T) {
 			expected: expected{
 				calls:      1,
 				statusCode: http.StatusOK,
-				reports: []models.EmployeeReportInboundDTO{
+				reports: []models.EmployeeReportInbound{
 					{ID: 1, CardNumberID: "3253", FirstName: "Rick", LastName: "Grimes", WarehouseID: 1, CountReports: 3},
 					{ID: 2, CardNumberID: "3254", FirstName: "Daryl", LastName: "Dixon", WarehouseID: 1, CountReports: 2},
 					{ID: 3, CardNumberID: "3255", FirstName: "Carol", LastName: "Peletier", WarehouseID: 1, CountReports: 1},
@@ -49,7 +49,7 @@ func TestGetReportInboundOrders(t *testing.T) {
 			expected: expected{
 				calls:      1,
 				statusCode: http.StatusOK,
-				reports: []models.EmployeeReportInboundDTO{
+				reports: []models.EmployeeReportInbound{
 					{ID: 1, CardNumberID: "3253", FirstName: "Rick", LastName: "Grimes", WarehouseID: 1, CountReports: 3},
 				},
 			},
@@ -61,7 +61,7 @@ func TestGetReportInboundOrders(t *testing.T) {
 			expected: expected{
 				calls:      1,
 				statusCode: http.StatusOK,
-				reports: []models.EmployeeReportInboundDTO{
+				reports: []models.EmployeeReportInbound{
 					{ID: 1, CardNumberID: "3253", FirstName: "Rick", LastName: "Grimes", WarehouseID: 1, CountReports: 0},
 				},
 			},
@@ -94,11 +94,11 @@ func TestGetReportInboundOrders(t *testing.T) {
 				calls:      1,
 				statusCode: http.StatusNotFound,
 				message:    "employee not found",
-				reports:    []models.EmployeeReportInboundDTO{},
+				reports:    []models.EmployeeReportInbound{},
 			},
 		},
 		{
-			name:    "500 - Internal server error when trying to retrieve inbound orders' report",
+			name:    "500 - Internal server error when trying to retrieve inbound orders' reports",
 			callErr: errors.New("internal error"),
 			id:      "1",
 			expected: expected{
@@ -130,8 +130,8 @@ func TestGetReportInboundOrders(t *testing.T) {
 			r.ServeHTTP(res, req)
 
 			var decodedRes struct {
-				Message string                            `json:"message,omitempty"`
-				Data    []models.EmployeeReportInboundDTO `json:"data,omitempty"`
+				Message string                         `json:"message,omitempty"`
+				Data    []models.EmployeeReportInbound `json:"data,omitempty"`
 			}
 			err := json.NewDecoder(res.Body).Decode(&decodedRes)
 

--- a/internal/controllers/employees/update_test.go
+++ b/internal/controllers/employees/update_test.go
@@ -125,7 +125,7 @@ func TestUpdate(t *testing.T) {
 			},
 		},
 		{
-			name:         "500 - Internal Server Error when trying to retrieve the list of employees",
+			name:         "500 - Internal Server Error when trying to update an employee",
 			id:           "1",
 			employeeJSON: `{"first_name":"Daryl","last_name":"Dixon"}`,
 			callErr:      errors.New("internal error"),

--- a/internal/controllers/employees/update_test.go
+++ b/internal/controllers/employees/update_test.go
@@ -149,7 +149,7 @@ func TestUpdate(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPatch, url, strings.NewReader(tt.employeeJSON))
 			res := httptest.NewRecorder()
 
-			sv.On("Update", mock.AnythingOfType("int"), mock.AnythingOfType("models.EmployeeDTO")).Return(tt.expected.employee, tt.callErr)
+			sv.On("Update", mock.AnythingOfType("models.EmployeeDTO"), mock.AnythingOfType("int")).Return(tt.expected.employee, tt.callErr)
 			r.ServeHTTP(res, req)
 
 			var decodedRes struct {

--- a/internal/models/employees.go
+++ b/internal/models/employees.go
@@ -22,7 +22,7 @@ type EmployeeDTO struct {
 	WarehouseID  *int    `json:"warehouse_id"`
 }
 
-type EmployeeReportInboundDTO struct {
+type EmployeeReportInbound struct {
 	ID           int
 	CardNumberID string
 	FirstName    string
@@ -34,7 +34,7 @@ type EmployeeReportInboundDTO struct {
 type EmployeesService interface {
 	GetAll() (employees []Employee, err error)
 	GetByID(id int) (employees Employee, err error)
-	GetReportInboundOrders(id int) (employees []EmployeeReportInboundDTO, err error)
+	GetReportInboundOrders(id int) (employees []EmployeeReportInbound, err error)
 	Create(employees EmployeeDTO) (newEmployees Employee, err error)
 	Update(employees EmployeeDTO, id int) (newEmployees Employee, err error)
 	Delete(id int) (err error)
@@ -43,7 +43,7 @@ type EmployeesService interface {
 type EmployeesRepository interface {
 	GetAll() (employees []Employee, err error)
 	GetByID(id int) (employees Employee, err error)
-	GetReportInboundOrders(id int) (employees []EmployeeReportInboundDTO, err error)
+	GetReportInboundOrders(id int) (employees []EmployeeReportInbound, err error)
 	Create(employees EmployeeDTO) (newEmployees Employee, err error)
 	Update(employees EmployeeDTO, id int) (newEmployees Employee, err error)
 	Delete(id int) (err error)

--- a/internal/repository/employees/employee_mock.go
+++ b/internal/repository/employees/employee_mock.go
@@ -23,23 +23,18 @@ func (m *EmployeeRepositoryMock) GetByID(id int) (models.Employee, error) {
 	return args.Get(0).(models.Employee), args.Error(1)
 }
 
-func (m *EmployeeRepositoryMock) GetReportInboundOrders(id int) ([]models.EmployeeReportInboundDTO, error) {
+func (m *EmployeeRepositoryMock) GetReportInboundOrders(id int) ([]models.EmployeeReportInbound, error) {
 	args := m.Called(id)
-	return args.Get(0).([]models.EmployeeReportInboundDTO), args.Error(1)
+	return args.Get(0).([]models.EmployeeReportInbound), args.Error(1)
 }
 
-func (m *EmployeeRepositoryMock) GetByCardNumberID(cardNumberID string) (models.Employee, error) {
-	args := m.Called(cardNumberID)
+func (m *EmployeeRepositoryMock) Create(employee models.EmployeeDTO) (models.Employee, error) {
+	args := m.Called(employee)
 	return args.Get(0).(models.Employee), args.Error(1)
 }
 
-func (m *EmployeeRepositoryMock) Create(buyer models.EmployeeDTO) (models.Employee, error) {
-	args := m.Called(buyer)
-	return args.Get(0).(models.Employee), args.Error(1)
-}
-
-func (m *EmployeeRepositoryMock) Update(buyer models.EmployeeDTO, id int) (buyerReturn models.Employee, err error) {
-	args := m.Called(id, buyer)
+func (m *EmployeeRepositoryMock) Update(employee models.EmployeeDTO, id int) (employeeReturn models.Employee, err error) {
+	args := m.Called(employee, id)
 	return args.Get(0).(models.Employee), args.Error(1)
 }
 

--- a/internal/repository/employees/get_report_inbound_orders.go
+++ b/internal/repository/employees/get_report_inbound_orders.go
@@ -4,7 +4,7 @@ import (
 	"github.com/maxwelbm/alkemy-g6/internal/models"
 )
 
-func (e *EmployeesRepository) GetReportInboundOrders(id int) (employeesReportList []models.EmployeeReportInboundDTO, err error) {
+func (e *EmployeesRepository) GetReportInboundOrders(id int) (employeesReportList []models.EmployeeReportInbound, err error) {
 	// selects locality info and carries count
 	query := `
 		SELECT e.id, e.card_number_id, e.first_name, e.last_name, e.warehouse_id ,COUNT(io.id) AS CountReports 
@@ -22,7 +22,7 @@ func (e *EmployeesRepository) GetReportInboundOrders(id int) (employeesReportLis
 	defer rows.Close()
 
 	for rows.Next() {
-		var employeesReport models.EmployeeReportInboundDTO
+		var employeesReport models.EmployeeReportInbound
 		if err = rows.Scan(&employeesReport.ID, &employeesReport.CardNumberID, &employeesReport.FirstName, &employeesReport.LastName, &employeesReport.WarehouseID, &employeesReport.CountReports); err != nil {
 			return nil, err
 		}

--- a/internal/service/employees_default.go
+++ b/internal/service/employees_default.go
@@ -28,7 +28,7 @@ func (e *EmployeesDefault) GetByID(id int) (employees models.Employee, err error
 	return
 }
 
-func (e *EmployeesDefault) GetReportInboundOrders(id int) (employees []models.EmployeeReportInboundDTO, err error) {
+func (e *EmployeesDefault) GetReportInboundOrders(id int) (employees []models.EmployeeReportInbound, err error) {
 	employees, err = e.rp.GetReportInboundOrders(id)
 	return
 }

--- a/internal/service/employees_default_test.go
+++ b/internal/service/employees_default_test.go
@@ -7,16 +7,9 @@ import (
 	"github.com/maxwelbm/alkemy-g6/internal/models"
 	employeesrp "github.com/maxwelbm/alkemy-g6/internal/repository/employees"
 	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-type Employee struct {
-	ID           int
-	CardNumberID string
-	FirstName    string
-	LastName     string
-	WarehouseID  int
-}
 
 var employeesFixture = []models.Employee{
 	{
@@ -113,6 +106,209 @@ func TestEmployeesDefault_GetByID(t *testing.T) {
 			employee, err := sv.GetByID(tt.employee.ID)
 
 			require.Equal(t, tt.expectedEmployee, employee)
+			require.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestEmployeesDefault_GetReportInboundOrders(t *testing.T) {
+	reports := []models.EmployeeReportInbound{
+		{
+			ID:           1,
+			CardNumberID: "1234",
+			FirstName:    "Rick",
+			LastName:     "Grimes",
+			WarehouseID:  1,
+			CountReports: 5,
+		},
+		{
+			ID:           2,
+			CardNumberID: "1235",
+			FirstName:    "Daryl",
+			LastName:     "Dixon",
+			WarehouseID:  1,
+			CountReports: 3,
+		},
+		{
+			ID:           3,
+			CardNumberID: "1236",
+			FirstName:    "Michonne",
+			LastName:     "Hawthorne",
+			WarehouseID:  1,
+			CountReports: 2,
+		},
+	}
+
+	tests := []struct {
+		name            string
+		id              int
+		reports         []models.EmployeeReportInbound
+		err             error
+		expectedReports []models.EmployeeReportInbound
+		expectedErr     error
+	}{
+		{
+			name:            "200 - Successfully retrieve inbound orders'reports for all existing employees",
+			id:              0,
+			reports:         reports,
+			err:             nil,
+			expectedReports: reports,
+			expectedErr:     nil,
+		},
+		{
+			name:            "200 - Successfully retrieve inbound orders' report for an employee id",
+			id:              1,
+			reports:         []models.EmployeeReportInbound{reports[0]},
+			err:             nil,
+			expectedReports: []models.EmployeeReportInbound{reports[0]},
+			expectedErr:     nil,
+		},
+		{
+			name:            "Error when retrieving employee with a non-existent ID",
+			id:              10,
+			reports:         []models.EmployeeReportInbound{},
+			err:             models.ErrEmployeeNotFound,
+			expectedReports: []models.EmployeeReportInbound{},
+			expectedErr:     models.ErrEmployeeNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rp := employeesrp.NewEmployeesRepositoryMock()
+			rp.On("GetReportInboundOrders", mock.AnythingOfType("int")).Return(tt.reports, tt.err)
+			sv := service.NewEmployeesService(rp)
+
+			reports, err := sv.GetReportInboundOrders(tt.id)
+
+			require.Equal(t, tt.expectedReports, reports)
+			require.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestEmployeesDefault_Create(t *testing.T) {
+	tests := []struct {
+		name             string
+		employee         models.Employee
+		err              error
+		expectedEmployee models.Employee
+		expectedErr      error
+	}{
+		{
+			name:             "Successfully create a new employee",
+			employee:         employeesFixture[2],
+			err:              nil,
+			expectedEmployee: employeesFixture[2],
+			expectedErr:      nil,
+		},
+		{
+			name:             "Error when trying to create a new employee",
+			employee:         models.Employee{},
+			err:              errors.New("internal error"),
+			expectedEmployee: models.Employee{},
+			expectedErr:      errors.New("internal error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			employeeDTO := models.EmployeeDTO{
+				ID:           &tt.employee.ID,
+				CardNumberID: &tt.employee.CardNumberID,
+				FirstName:    &tt.employee.FirstName,
+				LastName:     &tt.employee.LastName,
+				WarehouseID:  &tt.employee.WarehouseID,
+			}
+
+			rp := employeesrp.NewEmployeesRepositoryMock()
+			rp.On("Create", employeeDTO).Return(tt.employee, tt.err)
+			sv := service.NewEmployeesService(rp)
+
+			employee, err := sv.Create(employeeDTO)
+
+			require.Equal(t, tt.expectedEmployee, employee)
+			require.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestEmployeesDefault_Update(t *testing.T) {
+	tests := []struct {
+		name             string
+		id               int
+		employee         models.Employee
+		err              error
+		expectedEmployee models.Employee
+		expectedErr      error
+	}{
+		{
+			name:             "Successfully updated an employee",
+			employee:         employeesFixture[2],
+			err:              nil,
+			expectedEmployee: employeesFixture[2],
+			expectedErr:      nil,
+		},
+		{
+			name:             "Error when trying to update an employee",
+			employee:         models.Employee{},
+			err:              errors.New("internal error"),
+			expectedEmployee: models.Employee{},
+			expectedErr:      errors.New("internal error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			employeeDTO := models.EmployeeDTO{
+				ID:           &tt.employee.ID,
+				CardNumberID: &tt.employee.CardNumberID,
+				FirstName:    &tt.employee.FirstName,
+				LastName:     &tt.employee.LastName,
+				WarehouseID:  &tt.employee.WarehouseID,
+			}
+
+			rp := employeesrp.NewEmployeesRepositoryMock()
+			rp.On("Update", employeeDTO, tt.id).Return(tt.employee, tt.err)
+			sv := service.NewEmployeesService(rp)
+
+			employee, err := sv.Update(employeeDTO, tt.id)
+
+			require.Equal(t, tt.expectedEmployee, employee)
+			require.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestEmployeesDefault_Delete(t *testing.T) {
+	tests := []struct {
+		name        string
+		id          int
+		err         error
+		expectedErr error
+	}{
+		{
+			name:        "Successfully delete an employee",
+			id:          1,
+			err:         nil,
+			expectedErr: nil,
+		},
+		{
+			name:        "Error when trying to delete an employee",
+			id:          1,
+			err:         errors.New("internal error"),
+			expectedErr: errors.New("internal error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rp := employeesrp.NewEmployeesRepositoryMock()
+			rp.On("Delete", tt.id).Return(tt.err)
+			sv := service.NewEmployeesService(rp)
+
+			err := sv.Delete(tt.id)
+
 			require.Equal(t, tt.expectedErr, err)
 		})
 	}

--- a/internal/service/employees_default_test.go
+++ b/internal/service/employees_default_test.go
@@ -1,0 +1,119 @@
+package service_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	employeesrp "github.com/maxwelbm/alkemy-g6/internal/repository/employees"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+type Employee struct {
+	ID           int
+	CardNumberID string
+	FirstName    string
+	LastName     string
+	WarehouseID  int
+}
+
+var employeesFixture = []models.Employee{
+	{
+		ID:           1,
+		CardNumberID: "1234",
+		FirstName:    "Rick",
+		LastName:     "Grimes",
+		WarehouseID:  1,
+	},
+	{
+		ID:           2,
+		CardNumberID: "1235",
+		FirstName:    "Daryl",
+		LastName:     "Dixon",
+		WarehouseID:  1,
+	},
+	{
+		ID:           3,
+		CardNumberID: "1236",
+		FirstName:    "Michonne",
+		LastName:     "Hawthorne",
+		WarehouseID:  1,
+	},
+}
+
+func TestEmployeesDefault_GetAll(t *testing.T) {
+	tests := []struct {
+		name              string
+		employees         []models.Employee
+		err               error
+		expectedEmployees []models.Employee
+		expectedErr       error
+	}{
+		{
+			name:              "Successfully retrieve the list of existing employees",
+			employees:         employeesFixture,
+			err:               nil,
+			expectedEmployees: employeesFixture,
+			expectedErr:       nil,
+		},
+		{
+			name:              "Error when trying to retrieve the list of employees",
+			employees:         []models.Employee{},
+			err:               errors.New("internal error"),
+			expectedEmployees: []models.Employee{},
+			expectedErr:       errors.New("internal error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rp := employeesrp.NewEmployeesRepositoryMock()
+			rp.On("GetAll").Return(tt.employees, tt.err)
+			sv := service.NewEmployeesService(rp)
+
+			employee, err := sv.GetAll()
+
+			require.Equal(t, tt.expectedEmployees, employee)
+			require.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestEmployeesDefault_GetByID(t *testing.T) {
+	tests := []struct {
+		name             string
+		employee         models.Employee
+		err              error
+		expectedEmployee models.Employee
+		expectedErr      error
+	}{
+		{
+			name:             "Successfully retrieve employee details by existing ID",
+			employee:         employeesFixture[0],
+			err:              nil,
+			expectedEmployee: employeesFixture[0],
+			expectedErr:      nil,
+		},
+		{
+			name:             "Error when retrieving employee with a non-existent ID",
+			employee:         models.Employee{},
+			err:              models.ErrEmployeeNotFound,
+			expectedEmployee: models.Employee{},
+			expectedErr:      models.ErrEmployeeNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rp := employeesrp.NewEmployeesRepositoryMock()
+			rp.On("GetByID", tt.employee.ID).Return(tt.employee, tt.err)
+			sv := service.NewEmployeesService(rp)
+
+			employee, err := sv.GetByID(tt.employee.ID)
+
+			require.Equal(t, tt.expectedEmployee, employee)
+			require.Equal(t, tt.expectedErr, err)
+		})
+	}
+}

--- a/internal/service/employees_mock.go
+++ b/internal/service/employees_mock.go
@@ -23,9 +23,9 @@ func (m *EmployeeServiceMock) GetByID(id int) (models.Employee, error) {
 	return args.Get(0).(models.Employee), args.Error(1)
 }
 
-func (m *EmployeeServiceMock) GetReportInboundOrders(id int) ([]models.EmployeeReportInboundDTO, error) {
+func (m *EmployeeServiceMock) GetReportInboundOrders(id int) ([]models.EmployeeReportInbound, error) {
 	args := m.Called(id)
-	return args.Get(0).([]models.EmployeeReportInboundDTO), args.Error(1)
+	return args.Get(0).([]models.EmployeeReportInbound), args.Error(1)
 }
 
 func (m *EmployeeServiceMock) GetByCardNumberID(cardNumberID string) (models.Employee, error) {
@@ -33,13 +33,13 @@ func (m *EmployeeServiceMock) GetByCardNumberID(cardNumberID string) (models.Emp
 	return args.Get(0).(models.Employee), args.Error(1)
 }
 
-func (m *EmployeeServiceMock) Create(buyer models.EmployeeDTO) (models.Employee, error) {
-	args := m.Called(buyer)
+func (m *EmployeeServiceMock) Create(employee models.EmployeeDTO) (models.Employee, error) {
+	args := m.Called(employee)
 	return args.Get(0).(models.Employee), args.Error(1)
 }
 
-func (m *EmployeeServiceMock) Update(buyer models.EmployeeDTO, id int) (buyerReturn models.Employee, err error) {
-	args := m.Called(id, buyer)
+func (m *EmployeeServiceMock) Update(employee models.EmployeeDTO, id int) (employeeReturn models.Employee, err error) {
+	args := m.Called(employee, id)
 	return args.Get(0).(models.Employee), args.Error(1)
 }
 


### PR DESCRIPTION
## **Motivação**
Implementar testes unitários seguindo as especificações da historia: https://github.com/maxwelbm/alkemy-g6/issues/134

## **Solução proposta**
Este cartão cobre a implementação de testes para os seguintes endpoints da API de employees na camada de serviço:

GET /api/v1/employees/
GET /api/v1/employees/{id}
GET /api/v1/employees/reportInboundOrders
CREATE /api/v1/employees/
PATCH /api/v1/employees/{id}
DELETE /api/v1/employees/{id}

Os testes asseguram que as mensagens de resposta sejam claras e informativas em caso de falhas, proporcionando feedback útil ao usuário da API. Isso é fundamental para melhorar a experiência do desenvolvedor e a utilização do sistema.

## **Como testar**
go test -v ./internal/service/employees_default_test.go 

## **Comentários**
Correções nos nomes de alguns casos de teste para garantir que sejam descritivos e precisos.
Correções na ordem dos parâmetros nos mocks de serviço e repositório do método de PATCH de employee foi corrigida para refletir adequadamente a lógica de negócios.