### PR TITLE
Feat/product records get post controller tests

### DIFF
--- a/internal/controllers/product_records/create.go
+++ b/internal/controllers/product_records/create.go
@@ -68,7 +68,7 @@ func (p *ProductRecordReqJSON) validate() (err error) {
 // @Tags product_records
 // @Accept json
 // @Produce json
-// @Param productRecord body ProductRecordReqJSON true "Product Record Create JSON"
+// @Param productRecord body ProductRecordReqJSON true "Product Record Req JSON"
 // @Success 201 {object} ProductRecordResJSON "Success"
 // @Failure 400 {object} response.ErrorResponse "Bad Request"
 // @Failure 422 {object} response.ErrorResponse "Unprocessable Entity"

--- a/internal/controllers/product_records/create.go
+++ b/internal/controllers/product_records/create.go
@@ -11,40 +11,55 @@ import (
 	"github.com/maxwelbm/alkemy-g6/pkg/response"
 )
 
-type ProductRecordCreateJSON struct {
+type ProductRecordReqJSON struct {
 	LastUpdateDate *string  `json:"last_update_date,omitempty"`
 	PurchasePrice  *float64 `json:"purchase_price,omitempty"`
 	SalePrice      *float64 `json:"sale_price,omitempty"`
 	ProductID      *int     `json:"product_id,omitempty"`
 }
 
-func (j *ProductRecordCreateJSON) validate() (err error) {
+func (p *ProductRecordReqJSON) validate() (err error) {
 	// Initialize a slice to hold validation error messages
-	var validationErrors []string
+	var validationErrors, nilPointerErrors []string
 
 	// Check if LastUpdateDate is nil and add an error message if it is
-	if j.LastUpdateDate == nil {
-		validationErrors = append(validationErrors, "error: last_update_date is required")
+	if p.LastUpdateDate == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute LastUpdateDate cannot be nil")
+	} else if *p.LastUpdateDate == "" {
+		validationErrors = append(validationErrors, "error: attribute LastUpdateDate cannot be empty")
 	}
+
 	// Check if PurchasePrice is nil and add an error message if it is
-	if j.PurchasePrice == nil {
-		validationErrors = append(validationErrors, "error: purchase_price is required")
+	if p.PurchasePrice == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute PurchasePrice cannot be nil")
+	} else if *p.PurchasePrice <= 0 {
+		validationErrors = append(validationErrors, "error: attribute PurchasePrice must be greater than zero")
 	}
+
 	// Check if SalePrice is nil and add an error message if it is
-	if j.SalePrice == nil {
-		validationErrors = append(validationErrors, "error: sale_price is required")
+	if p.SalePrice == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute SalePrice cannot be nil")
+	} else if *p.SalePrice <= 0 {
+		validationErrors = append(validationErrors, "error: attribute SalePrice must be greater than zero")
 	}
+
 	// Check if ProductID is nil and add an error message if it is
-	if j.ProductID == nil {
-		validationErrors = append(validationErrors, "error: product_id is required")
+	if p.ProductID == nil {
+		nilPointerErrors = append(nilPointerErrors, "error: attribute ProductID cannot be nil")
+	} else if *p.ProductID <= 0 {
+		validationErrors = append(validationErrors, "error: attribute ProductID must be greater than zero")
 	}
-	// If there are any validation errors, create an error with all messages
-	if len(validationErrors) > 0 {
-		err = fmt.Errorf("validation errors: %v", validationErrors)
+	// If there are any validation errors or nil pointer errors, create an error with all messages
+	if len(nilPointerErrors) > 0 || len(validationErrors) > 0 {
+		var allErrors []string
+		allErrors = append(allErrors, nilPointerErrors...)
+		allErrors = append(allErrors, validationErrors...)
+
+		err = fmt.Errorf("validation errors: %v", allErrors)
 	}
 
 	// Return the error (if any)
-	return
+	return err
 }
 
 // Create handles the creation of a new product record.
@@ -53,7 +68,7 @@ func (j *ProductRecordCreateJSON) validate() (err error) {
 // @Tags product_records
 // @Accept json
 // @Produce json
-// @Param productRecord body ProductRecordCreateJSON true "Product Record Create JSON"
+// @Param productRecord body ProductRecordReqJSON true "Product Record Create JSON"
 // @Success 201 {object} ProductRecordResJSON "Success"
 // @Failure 400 {object} response.ErrorResponse "Bad Request"
 // @Failure 422 {object} response.ErrorResponse "Unprocessable Entity"
@@ -62,7 +77,7 @@ func (j *ProductRecordCreateJSON) validate() (err error) {
 // @Router /api/v1/product_records [post]
 func (controller *ProductRecordsDefault) Create(w http.ResponseWriter, r *http.Request) {
 	// Decode the JSON request body into productRecordRequest
-	var productRecordRequest ProductRecordCreateJSON
+	var productRecordRequest ProductRecordReqJSON
 	if err := json.NewDecoder(r.Body).Decode(&productRecordRequest); err != nil {
 		// If there's an error decoding the JSON, respond with a bad request status
 		response.Error(w, http.StatusBadRequest, err.Error())

--- a/internal/controllers/product_records/create_test.go
+++ b/internal/controllers/product_records/create_test.go
@@ -1,0 +1,129 @@
+package productrecordsctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	productrecordsctl "github.com/maxwelbm/alkemy-g6/internal/controllers/product_records"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreate(t *testing.T) {
+	type expected struct {
+		calls         int
+		statusCode    int
+		message       string
+		productRecord models.ProductRecord
+	}
+	tests := []struct {
+		name              string
+		productRecordJSON string
+		callErr           error
+		expected          expected
+	}{
+		{
+			name:              "201 - Successfully created a productRecord",
+			productRecordJSON: `{"last_update_date":"2021-09-01","purchase_price":10.5,"sale_price":15.5,"product_id":1}`,
+			callErr:           nil,
+			expected: expected{
+				calls:         1,
+				statusCode:    http.StatusCreated,
+				productRecord: models.ProductRecord{ID: 1, LastUpdateDate: "2021-09-01", PurchasePrice: 10.5, SalePrice: 15.5, ProductID: 1},
+			},
+		},
+		{
+			name:              "400 - Bad Request error when trying to create a productRecord",
+			productRecordJSON: `{"last_update_date":"2021-09-01","purchase_price":"10.5","sale_price":15.5,"product_id":1}`,
+			callErr:           nil,
+			expected: expected{
+				calls:      0,
+				statusCode: http.StatusBadRequest,
+				message:    "json: cannot unmarshal",
+			},
+		},
+		{
+			name:              "409 - Conflict error when trying to create an productRecords with an inexistent productID",
+			productRecordJSON: `{"last_update_date":"2021-09-01","purchase_price":10.5,"sale_price":15.5,"product_id":10}`,
+			callErr:           &mysql.MySQLError{Number: mysqlerr.CodeCannotAddOrUpdateChildRow},
+			expected: expected{
+				calls:         1,
+				statusCode:    http.StatusConflict,
+				message:       "1452",
+				productRecord: models.ProductRecord{},
+			},
+		},
+		{
+			name:              "422 - Conflict error when trying to create an productRecords with empty parameters",
+			productRecordJSON: `{"last_update_date":"","purchase_price":10.5,"sale_price":15.5,"product_id":1}`,
+			callErr:           nil,
+			expected: expected{
+				calls:         0,
+				statusCode:    http.StatusUnprocessableEntity,
+				message:       "error: attribute LastUpdateDate cannot be empty",
+				productRecord: models.ProductRecord{},
+			},
+		},
+		{
+			name:              "422 - Conflict error when trying to create an productRecords with missing parameters",
+			productRecordJSON: `{"last_update_date":"2021-09-01","purchase_price":10.5,"sale_price":15.5}`,
+			callErr:           nil,
+			expected: expected{
+				calls:         0,
+				statusCode:    http.StatusUnprocessableEntity,
+				message:       "error: attribute ProductID cannot be nil",
+				productRecord: models.ProductRecord{},
+			},
+		},
+		{
+			name:              "500 - Internal Server Error when trying to retrieve the list of productRecordss",
+			productRecordJSON: `{"last_update_date":"2021-09-01","purchase_price":10.5,"sale_price":15.5,"product_id":1}`,
+			callErr:           errors.New("internal error"),
+			expected: expected{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sv := service.NewProductRecordsServiceMock()
+			ctl := controllers.NewProductRecordsController(sv)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/productRecords", strings.NewReader(tt.productRecordJSON))
+			res := httptest.NewRecorder()
+
+			sv.On("Create", mock.AnythingOfType("models.ProductRecordDTO")).Return(tt.expected.productRecord, tt.callErr)
+			ctl.Create(res, req)
+
+			var decodedRes struct {
+				Message string                                  `json:"message,omitempty"`
+				Data    productrecordsctl.FullProductRecordJSON `json:"data,omitempty"`
+			}
+			err := json.NewDecoder(res.Body).Decode(&decodedRes)
+
+			sv.AssertNumberOfCalls(t, "Create", tt.expected.calls)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected.statusCode, res.Code)
+			if tt.expected.statusCode == http.StatusOK {
+				require.Equal(t, tt.expected.productRecord.ID, decodedRes.Data.ID)
+				require.Equal(t, tt.expected.productRecord.LastUpdateDate, decodedRes.Data.LastUpdateDate)
+				require.Equal(t, tt.expected.productRecord.PurchasePrice, decodedRes.Data.PurchasePrice)
+				require.Equal(t, tt.expected.productRecord.SalePrice, decodedRes.Data.SalePrice)
+				require.Equal(t, tt.expected.productRecord.ProductID, decodedRes.Data.ProductID)
+			}
+			require.Contains(t, decodedRes.Message, tt.expected.message)
+		})
+	}
+}

--- a/internal/repository/product_records/product_records_mock.go
+++ b/internal/repository/product_records/product_records_mock.go
@@ -1,0 +1,19 @@
+package productrecordsrp
+
+import (
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/stretchr/testify/mock"
+)
+
+type ProductRecordsRepositoryMock struct {
+	mock.Mock
+}
+
+func NewProductRecordsRepositoryMock() *ProductRecordsRepositoryMock {
+	return &ProductRecordsRepositoryMock{}
+}
+
+func (m *ProductRecordsRepositoryMock) Create(employee models.ProductRecordDTO) (models.ProductRecord, error) {
+	args := m.Called(employee)
+	return args.Get(0).(models.ProductRecord), args.Error(1)
+}

--- a/internal/repository/products/create.go
+++ b/internal/repository/products/create.go
@@ -70,10 +70,6 @@ func (p *Products) Create(prod models.ProductDTO) (newProd models.Product, err e
 		&newProd.ProductTypeID,
 		&newProd.SellerID,
 	)
-	
-	if err != nil {
-		return newProd, err
-	}
 
 	return newProd, err
 }

--- a/internal/repository/products/update.go
+++ b/internal/repository/products/update.go
@@ -5,22 +5,7 @@ import (
 )
 
 func (p *Products) Update(id int, prod models.ProductDTO) (updatedProd models.Product, err error) {
-	if prod.ProductCode != "" {
-		var exists bool
-
-		query := "SELECT EXISTS(SELECT 1 FROM products WHERE `product_code`=?)"
-		err = p.DB.QueryRow(query, prod.ProductCode).Scan(&exists)
-
-		if err != nil {
-			return updatedProd, err
-		}
-
-		if !exists {
-			err = models.ErrProductNotFound
-			return updatedProd, err
-		}
-	}
-
+	// Define the update query
 	query := `UPDATE products SET 
 			product_code = COALESCE(NULLIF(?, ''), product_code), 
 			description = COALESCE(NULLIF(?, ''), description),

--- a/internal/service/employees_mock.go
+++ b/internal/service/employees_mock.go
@@ -28,11 +28,6 @@ func (m *EmployeeServiceMock) GetReportInboundOrders(id int) ([]models.EmployeeR
 	return args.Get(0).([]models.EmployeeReportInbound), args.Error(1)
 }
 
-func (m *EmployeeServiceMock) GetByCardNumberID(cardNumberID string) (models.Employee, error) {
-	args := m.Called(cardNumberID)
-	return args.Get(0).(models.Employee), args.Error(1)
-}
-
 func (m *EmployeeServiceMock) Create(employee models.EmployeeDTO) (models.Employee, error) {
 	args := m.Called(employee)
 	return args.Get(0).(models.Employee), args.Error(1)

--- a/internal/service/product_records_default_test.go
+++ b/internal/service/product_records_default_test.go
@@ -1,0 +1,65 @@
+package service_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	productrecordsrp "github.com/maxwelbm/alkemy-g6/internal/repository/product_records"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProductRecordsDefault_Create(t *testing.T) {
+	newProductRecord := models.ProductRecord{
+		ID:             4,
+		LastUpdateDate: "2021-09-01",
+		PurchasePrice:  10.5,
+		SalePrice:      15.5,
+		ProductID:      1,
+	}
+
+	tests := []struct {
+		name                  string
+		productRecord         models.ProductRecord
+		err                   error
+		expectedProductRecord models.ProductRecord
+		expectedErr           error
+	}{
+		{
+			name:                  "Successfully create a new productRecord",
+			productRecord:         newProductRecord,
+			err:                   nil,
+			expectedProductRecord: newProductRecord,
+			expectedErr:           nil,
+		},
+		{
+			name:                  "Error when trying to create a new productRecord",
+			productRecord:         models.ProductRecord{},
+			err:                   errors.New("internal error"),
+			expectedProductRecord: models.ProductRecord{},
+			expectedErr:           errors.New("internal error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			productRecordDTO := models.ProductRecordDTO{
+				ID:             tt.productRecord.ID,
+				LastUpdateDate: tt.productRecord.LastUpdateDate,
+				PurchasePrice:  tt.productRecord.PurchasePrice,
+				SalePrice:      tt.productRecord.SalePrice,
+				ProductID:      tt.productRecord.ProductID,
+			}
+
+			rp := productrecordsrp.NewProductRecordsRepositoryMock()
+			rp.On("Create", productRecordDTO).Return(tt.productRecord, tt.err)
+			sv := service.NewProductRecordsService(rp)
+
+			productRecord, err := sv.Create(productRecordDTO)
+
+			require.Equal(t, tt.expectedProductRecord, productRecord)
+			require.Equal(t, tt.expectedErr, err)
+		})
+	}
+}

--- a/internal/service/product_records_mock.go
+++ b/internal/service/product_records_mock.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/stretchr/testify/mock"
+)
+
+type ProductRecordServiceMock struct {
+	mock.Mock
+}
+
+func NewProductRecordsServiceMock() *ProductRecordServiceMock {
+	return &ProductRecordServiceMock{}
+}
+
+func (m *ProductRecordServiceMock) Create(buyer models.ProductRecordDTO) (models.ProductRecord, error) {
+	args := m.Called(buyer)
+	return args.Get(0).(models.ProductRecord), args.Error(1)
+}

--- a/swagger/docs/docs.go
+++ b/swagger/docs/docs.go
@@ -904,12 +904,12 @@ const docTemplate = `{
                 "summary": "Create a new product record",
                 "parameters": [
                     {
-                        "description": "Product Record Create JSON",
+                        "description": "Product Record Req JSON",
                         "name": "productRecord",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/productrecordsctl.ProductRecordCreateJSON"
+                            "$ref": "#/definitions/productrecordsctl.ProductRecordReqJSON"
                         }
                     }
                 ],
@@ -2297,7 +2297,7 @@ const docTemplate = `{
                 }
             }
         },
-        "productrecordsctl.ProductRecordCreateJSON": {
+        "productrecordsctl.ProductRecordReqJSON": {
             "type": "object",
             "properties": {
                 "last_update_date": {

--- a/swagger/docs/swagger.json
+++ b/swagger/docs/swagger.json
@@ -897,12 +897,12 @@
                 "summary": "Create a new product record",
                 "parameters": [
                     {
-                        "description": "Product Record Create JSON",
+                        "description": "Product Record Req JSON",
                         "name": "productRecord",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/productrecordsctl.ProductRecordCreateJSON"
+                            "$ref": "#/definitions/productrecordsctl.ProductRecordReqJSON"
                         }
                     }
                 ],
@@ -2290,7 +2290,7 @@
                 }
             }
         },
-        "productrecordsctl.ProductRecordCreateJSON": {
+        "productrecordsctl.ProductRecordReqJSON": {
             "type": "object",
             "properties": {
                 "last_update_date": {

--- a/swagger/docs/swagger.yaml
+++ b/swagger/docs/swagger.yaml
@@ -162,7 +162,7 @@ definitions:
       message:
         type: string
     type: object
-  productrecordsctl.ProductRecordCreateJSON:
+  productrecordsctl.ProductRecordReqJSON:
     properties:
       last_update_date:
         type: string
@@ -955,12 +955,12 @@ paths:
       - application/json
       description: Create a new product record with the provided JSON data
       parameters:
-      - description: Product Record Create JSON
+      - description: Product Record Req JSON
         in: body
         name: productRecord
         required: true
         schema:
-          $ref: '#/definitions/productrecordsctl.ProductRecordCreateJSON'
+          $ref: '#/definitions/productrecordsctl.ProductRecordReqJSON'
       produces:
       - application/json
       responses:


### PR DESCRIPTION
## **Motivação**
Implementar testes unitários seguindo as especificações da historia: https://github.com/maxwelbm/alkemy-g6/issues/134

## **Solução proposta**
Este cartão tem como objetivo implementar testes na camada de controller: Implementar testes para o endpoint da API relacionados a productRecords, utilizando mocks para a lógica de serviço.

Endpoint: POST /api/v1/productRecords

Cobertura de cenários: Garantir que operação de CREATE funcione conforme o esperado, incluindo casos de erro, para detectar e corrigir falhas antes que impactem a API em produção. Esses testes visam aumentar a robustez da API e melhorar a qualidade do código.

## **Como testar**
go test -v ./internal/service/product_records_default_test.go

## **Comentários**
Correções de nome de estruturas de productRecords para estar em conformidade com o formato.
Correções nas validações de productRecords no método create.