### PR TITLE
Feat/test carries

### DIFF
--- a/internal/controllers/carries/create.go
+++ b/internal/controllers/carries/create.go
@@ -19,36 +19,57 @@ type CarriesCreateJSON struct {
 	LocalityID  *int    `json:"locality_id"`
 }
 
+//nolint:gocyclo
 func (j *CarriesCreateJSON) validate() (err error) {
 	// Initialize a slice to hold validation error messages
 	var validationErrors []string
 
 	// Check if CID is nil and add an error message if it is
 	if j.CID == nil {
-		validationErrors = append(validationErrors, "error: cid is required")
+		validationErrors = append(validationErrors, "error: cid cannot be nil")
+	}
+	// Check if CID is empty and add an error message if it is
+	if j.CID != nil && *j.CID == "" {
+		validationErrors = append(validationErrors, "error: cid cannot be empty")
 	}
 	// Check if CompanyName is nil and add an error message if it is
 	if j.CompanyName == nil {
-		validationErrors = append(validationErrors, "error: company_name is required")
+		validationErrors = append(validationErrors, "error: company_name cannot be nil")
+	}
+	// Check if CompanyName is empty and add an error message if it is
+	if j.CompanyName != nil && *j.CompanyName == "" {
+		validationErrors = append(validationErrors, "error: company_name cannot be empty")
 	}
 	// Check if Address is nil and add an error message if it is
 	if j.Address == nil {
-		validationErrors = append(validationErrors, "error: address is required")
+		validationErrors = append(validationErrors, "error: address cannot be nil")
+	}
+	// Check if Address is empty and add an error message if it is
+	if j.Address != nil && *j.Address == "" {
+		validationErrors = append(validationErrors, "error: address cannot be empty")
 	}
 	// Check if PhoneNumber is nil and add an error message if it is
 	if j.PhoneNumber == nil {
-		validationErrors = append(validationErrors, "error: phone_number is required")
+		validationErrors = append(validationErrors, "error: phone_number cannot be nil")
+	}
+	// Check if PhoneNumber is empty and add an error message if it is
+	if j.PhoneNumber != nil && *j.PhoneNumber == "" {
+		validationErrors = append(validationErrors, "error: phone_number cannot be empty")
 	}
 	// Check if LocalityID is nil and add an error message if it is
 	if j.LocalityID == nil {
-		validationErrors = append(validationErrors, "error: locality_id is required")
+		validationErrors = append(validationErrors, "error: locality_id cannot be nil")
+	}
+	// Check if LocalityID is 0 and add an error message if it is
+	if j.LocalityID != nil && *j.LocalityID == 0 {
+		validationErrors = append(validationErrors, "error: locality_id cannot be 0")
 	}
 	// If there are any validation errors, create an error with all messages
 	if len(validationErrors) > 0 {
 		err = fmt.Errorf("validation errors: %v", validationErrors)
 	}
 
-	return
+	return err
 }
 
 // Create creates a new carry
@@ -80,11 +101,11 @@ func (ctl *CarriesDefault) Create(w http.ResponseWriter, r *http.Request) {
 
 	// Map the request data to a CarriesDTO model
 	carryToCreate := models.CarryDTO{
-		CID:         *carryRequest.CID,
-		CompanyName: *carryRequest.CompanyName,
-		Address:     *carryRequest.Address,
-		PhoneNumber: *carryRequest.PhoneNumber,
-		LocalityID:  *carryRequest.LocalityID,
+		CID:         carryRequest.CID,
+		CompanyName: carryRequest.CompanyName,
+		Address:     carryRequest.Address,
+		PhoneNumber: carryRequest.PhoneNumber,
+		LocalityID:  carryRequest.LocalityID,
 	}
 
 	// Call the service layer to create the carry
@@ -92,8 +113,8 @@ func (ctl *CarriesDefault) Create(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Check if the error is a MySQL duplicate entry error or cannot add or update child row error
 		if mysqlErr, ok := err.(*mysql.MySQLError); ok &&
-			mysqlErr.Number == mysqlerr.CodeDuplicateEntry ||
-			mysqlErr.Number == mysqlerr.CodeCannotAddOrUpdateChildRow {
+			(mysqlErr.Number == mysqlerr.CodeDuplicateEntry ||
+				mysqlErr.Number == mysqlerr.CodeCannotAddOrUpdateChildRow) {
 			response.Error(w, http.StatusConflict, err.Error())
 			return
 		}

--- a/internal/controllers/carries/create_test.go
+++ b/internal/controllers/carries/create_test.go
@@ -1,0 +1,180 @@
+package carriesctl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/maxwelbm/alkemy-g6/internal/controllers"
+	carriesctl "github.com/maxwelbm/alkemy-g6/internal/controllers/carries"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreate(t *testing.T) {
+	type wanted struct {
+		calls      int
+		statusCode int
+		message    string
+		carrie     models.Carry
+	}
+	tests := []struct {
+		name       string
+		carrieJSON string
+		callErr    error
+		wanted     wanted
+	}{
+		{
+			name: "201 - When the carrie is created successfully",
+			carrieJSON: `{
+				"cid": "123456789",
+				"company_name": "Carry 1",
+				"address": "Rua legal",
+				"phone_number": "123456789",
+				"locality_id": 1
+			}`,
+			callErr: nil,
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusCreated,
+				message:    "Created",
+				carrie: models.Carry{
+					ID:          1,
+					CID:         "123456789",
+					CompanyName: "Carry 1",
+					Address:     "Rua legal",
+					PhoneNumber: "123456789",
+					LocalityID:  1,
+				},
+			},
+		},
+		{
+			name: "400 - When passing a body with invalid json",
+			carrieJSON: `{
+				"cid": 123456789,
+				"company_name": "Carry 1",
+				"address": "Rua legal",
+				"phone_number": "123456789",
+				"locality_id": 1
+			}`,
+			callErr: nil,
+			wanted: wanted{
+				statusCode: http.StatusBadRequest,
+				message:    "json: cannot unmarshal",
+			},
+		},
+		{
+			name: "422 - When passing a body with a valid json with missing parameters",
+			carrieJSON: `{
+				"cid": "123456789",
+				"address": "Rua legal",
+				"phone_number": "123456789",
+				"locality_id": 1
+			}`,
+			callErr: nil,
+			wanted: wanted{
+				statusCode: http.StatusUnprocessableEntity,
+				message:    "company_name cannot be nil",
+			},
+		},
+		{
+			name: "422 - When passing a body with a valid json with empty parameters",
+			carrieJSON: `{
+				"cid": "123456789",
+				"company_name": "",
+				"address": "Rua legal",
+				"phone_number": "123456789",
+				"locality_id": 1
+			}`,
+			callErr: nil,
+			wanted: wanted{
+				statusCode: http.StatusUnprocessableEntity,
+				message:    "company_name cannot be empty",
+			},
+		},
+		{
+			name: "409 - When the repository raises a DuplicateEntry error",
+			carrieJSON: `{
+				"cid": "123456789",
+				"company_name": "Carry 1",
+				"address": "Rua legal",
+				"phone_number": "123456789",
+				"locality_id": 1
+			}`,
+			callErr: &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusConflict,
+				message:    "1062",
+				carrie:     models.Carry{},
+			},
+		},
+		{
+			name: "500 - When the repository returns an unexpected error",
+			carrieJSON: `{
+				"cid": "123456789",
+				"company_name": "Carry 1",
+				"address": "Rua legal",
+				"phone_number": "123456789",
+				"locality_id": 1
+			}`,
+			callErr: errors.New("internal error"),
+			wanted: wanted{
+				calls:      1,
+				statusCode: http.StatusInternalServerError,
+				message:    "internal error",
+				carrie:     models.Carry{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sv := service.NewCarriesServiceMock()
+			ctl := controllers.NewCarriesController(sv)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/carries", strings.NewReader(tt.carrieJSON))
+			res := httptest.NewRecorder()
+
+			// Act
+			sv.On("Create", mock.MatchedBy(func(dto models.CarryDTO) bool {
+				if tt.callErr != nil {
+					return true
+				}
+				return (*dto.CID == tt.wanted.carrie.CID &&
+					*dto.CompanyName == tt.wanted.carrie.CompanyName &&
+					*dto.Address == tt.wanted.carrie.Address &&
+					*dto.PhoneNumber == tt.wanted.carrie.PhoneNumber &&
+					*dto.LocalityID == tt.wanted.carrie.LocalityID)
+			})).Return(tt.wanted.carrie, tt.callErr)
+			ctl.Create(res, req)
+
+			// Assert
+			var decodedRes struct {
+				Message string                   `json:"message,omitempty"`
+				Data    carriesctl.FullCarryJSON `json:"data,omitempty"`
+			}
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&decodedRes))
+
+			sv.AssertNumberOfCalls(t, "Create", tt.wanted.calls)
+			require.Equal(t, tt.wanted.statusCode, res.Code)
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+			if tt.wanted.statusCode == http.StatusCreated {
+				require.Equal(t, tt.wanted.carrie.CID, decodedRes.Data.CID)
+				require.Equal(t, tt.wanted.carrie.CompanyName, decodedRes.Data.CompanyName)
+				require.Equal(t, tt.wanted.carrie.Address, decodedRes.Data.Address)
+				require.Equal(t, tt.wanted.carrie.PhoneNumber, decodedRes.Data.PhoneNumber)
+				require.Equal(t, tt.wanted.carrie.LocalityID, decodedRes.Data.LocalityID)
+			}
+			require.Contains(t, decodedRes.Message, tt.wanted.message)
+		})
+	}
+}

--- a/internal/models/carries.go
+++ b/internal/models/carries.go
@@ -16,11 +16,11 @@ type Carry struct {
 }
 
 type CarryDTO struct {
-	CID         string
-	CompanyName string
-	Address     string
-	PhoneNumber string
-	LocalityID  int
+	CID         *string
+	CompanyName *string
+	Address     *string
+	PhoneNumber *string
+	LocalityID  *int
 }
 
 type CarriesService interface {

--- a/internal/repository/carries/carries_default_mock.go
+++ b/internal/repository/carries/carries_default_mock.go
@@ -13,7 +13,7 @@ func NewCarriesRepositoryMock() *CarryDefaultMock {
 	return &CarryDefaultMock{}
 }
 
-func (m *CarryDefaultMock) Create(buyer models.CarryDTO) (models.Carry, error) {
-	args := m.Called(buyer)
+func (m *CarryDefaultMock) Create(carry models.CarryDTO) (models.Carry, error) {
+	args := m.Called(carry)
 	return args.Get(0).(models.Carry), args.Error(1)
 }

--- a/internal/repository/carries/carries_default_mock.go
+++ b/internal/repository/carries/carries_default_mock.go
@@ -1,0 +1,19 @@
+package carriesrp
+
+import (
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/stretchr/testify/mock"
+)
+
+type CarryDefaultMock struct {
+	mock.Mock
+}
+
+func NewCarriesRepositoryMock() *CarryDefaultMock {
+	return &CarryDefaultMock{}
+}
+
+func (m *CarryDefaultMock) Create(buyer models.CarryDTO) (models.Carry, error) {
+	args := m.Called(buyer)
+	return args.Get(0).(models.Carry), args.Error(1)
+}

--- a/internal/service/carries_default_mock.go
+++ b/internal/service/carries_default_mock.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/stretchr/testify/mock"
+)
+
+type CarryDefaultMock struct {
+	mock.Mock
+}
+
+func NewCarriesServiceMock() *CarryDefaultMock {
+	return &CarryDefaultMock{}
+}
+
+func (m *CarryDefaultMock) Create(buyer models.CarryDTO) (models.Carry, error) {
+	args := m.Called(buyer)
+	return args.Get(0).(models.Carry), args.Error(1)
+}

--- a/internal/service/carries_default_mock.go
+++ b/internal/service/carries_default_mock.go
@@ -13,7 +13,7 @@ func NewCarriesServiceMock() *CarryDefaultMock {
 	return &CarryDefaultMock{}
 }
 
-func (m *CarryDefaultMock) Create(buyer models.CarryDTO) (models.Carry, error) {
-	args := m.Called(buyer)
+func (m *CarryDefaultMock) Create(carry models.CarryDTO) (models.Carry, error) {
+	args := m.Called(carry)
 	return args.Get(0).(models.Carry), args.Error(1)
 }

--- a/internal/service/carries_default_test.go
+++ b/internal/service/carries_default_test.go
@@ -1,0 +1,68 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	carriesrp "github.com/maxwelbm/alkemy-g6/internal/repository/carries"
+	"github.com/maxwelbm/alkemy-g6/internal/service"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
+	"github.com/stretchr/testify/require"
+)
+
+var carryFixture = models.Carry{
+	ID:          1,
+	CID:         "123",
+	CompanyName: "Company A",
+	Address:     "123 Street",
+	PhoneNumber: "012345678",
+	LocalityID:  1,
+}
+
+func TestCarriesDefault_Create(t *testing.T) {
+	tests := []struct {
+		name        string
+		carry       models.Carry
+		err         error
+		wantedCarry models.Carry
+		wantedErr   error
+	}{
+		{
+			name:        "When the repository returns a carry",
+			carry:       carryFixture,
+			err:         nil,
+			wantedCarry: carryFixture,
+			wantedErr:   nil,
+		},
+		{
+			name:        "When the repository returns an error",
+			carry:       carryFixture,
+			err:         &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
+			wantedCarry: carryFixture,
+			wantedErr:   &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			rp := carriesrp.NewCarriesRepositoryMock()
+			sv := service.NewCarriesService(rp)
+			dto := models.CarryDTO{
+				CID:         &tt.carry.CID,
+				CompanyName: &tt.carry.CompanyName,
+				Address:     &tt.carry.Address,
+				PhoneNumber: &tt.carry.PhoneNumber,
+				LocalityID:  &tt.carry.LocalityID,
+			}
+			// Act
+			rp.On("Create", dto).Return(tt.carry, tt.err)
+			carry, err := sv.Create(dto)
+
+			// Assert
+			require.Equal(t, tt.wantedCarry, carry)
+			require.Equal(t, tt.wantedErr, err)
+		})
+	}
+}


### PR DESCRIPTION
## Motivação
<!-- Qual é a motivação por trás desta mudança? -->
Implementar testes no recurso `carries` conforme os requisitos da história https://github.com/maxwelbm/alkemy-g6/issues/193

## Solução proposta
<!-- Quais mudanças esta PR propõe? -->
Adiciona testes dos seguintes cenários p/ o controller create de carries:
- "201 - Quando o carrinho é criado com sucesso",
-  "400 - Ao passar um corpo com JSON inválido",
- "422 - Ao passar um corpo com um JSON válido com parâmetros faltando",
- "422 - Ao passar um corpo com um JSON válido com parâmetros vazios",
- "409 - Quando o repositório gera um erro de DuplicateEntry (Entrada Duplicada)",
- "500 - Quando o repositório retorna um erro inesperado",

Adiciona dois testes simples para o service de `Create`para carries, quando o service cria um carry corretamente ou quando é retornado um erro

## Como testar
<!-- Descreva como testar as mudanças propostas. -->
execute os testes automatizados com o comando:
```sh
make test
```

## Link p/ história
<!-- Link para qualquer história ou issue relacionada (se aplicável). -->
https://github.com/maxwelbm/alkemy-g6/issues/193

## Comentário(s)
<!-- Comentários ou informações adicionais para os revisores. -->

