### PR TITLE
refactor create and update to test for seller

### DIFF
--- a/internal/controllers/seller/create_test.go
+++ b/internal/controllers/seller/create_test.go
@@ -70,6 +70,7 @@ func TestCreate(t *testing.T) {
 			wanted: wanted{
 				statusCode: http.StatusBadRequest,
 				message:    "json: cannot unmarshal",
+				seller:     models.Seller{},
 			},
 		},
 		{
@@ -81,6 +82,7 @@ func TestCreate(t *testing.T) {
 			wanted: wanted{
 				statusCode: http.StatusUnprocessableEntity,
 				message:    "error: cid is required",
+				seller:     models.Seller{},
 			},
 		},
 		{
@@ -150,6 +152,18 @@ func TestCreate(t *testing.T) {
 
 			// Act
 			sv.On("Create", mock.AnythingOfType("models.SellerDTO")).Return(tt.wanted.seller, tt.callErr)
+
+			sv.On("Create", mock.MatchedBy(func(dto models.SellerDTO) bool {
+				if tt.callErr != nil {
+					return true
+				}
+				return (dto.CID == tt.wanted.seller.CID &&
+					dto.Address == tt.wanted.seller.Address &&
+					dto.CompanyName == tt.wanted.seller.CompanyName &&
+					dto.Telephone == tt.wanted.seller.Telephone &&
+					dto.LocalityID == tt.wanted.seller.LocalityID)
+			})).Return(tt.wanted.seller, tt.callErr)
+
 			ctl.Create(res, req)
 
 			// Assert

--- a/internal/controllers/seller/update_test.go
+++ b/internal/controllers/seller/update_test.go
@@ -73,6 +73,7 @@ func TestUpdate(t *testing.T) {
 			wanted: wanted{
 				statusCode: http.StatusBadRequest,
 				message:    "strconv.Atoi",
+				seller:     models.Seller{},
 			},
 		},
 		{
@@ -90,6 +91,7 @@ func TestUpdate(t *testing.T) {
 			wanted: wanted{
 				statusCode: http.StatusBadRequest,
 				message:    "Bad Request",
+				seller:     models.Seller{},
 			},
 		},
 		{
@@ -107,6 +109,7 @@ func TestUpdate(t *testing.T) {
 			wanted: wanted{
 				statusCode: http.StatusBadRequest,
 				message:    "json: cannot unmarshal",
+				seller:     models.Seller{},
 			},
 		},
 		{
@@ -124,6 +127,7 @@ func TestUpdate(t *testing.T) {
 			wanted: wanted{
 				statusCode: http.StatusUnprocessableEntity,
 				message:    "error: attribute CID cannot be empty",
+				seller:     models.Seller{},
 			},
 		},
 		{
@@ -142,6 +146,7 @@ func TestUpdate(t *testing.T) {
 				calls:      1,
 				statusCode: http.StatusNotFound,
 				message:    "seller not found",
+				seller:     models.Seller{},
 			},
 		},
 
@@ -161,6 +166,7 @@ func TestUpdate(t *testing.T) {
 				calls:      1,
 				statusCode: http.StatusConflict,
 				message:    "1062",
+				seller:     models.Seller{},
 			},
 		},
 		{
@@ -179,6 +185,7 @@ func TestUpdate(t *testing.T) {
 				calls:      1,
 				statusCode: http.StatusInternalServerError,
 				message:    "Generic error",
+				seller:     models.Seller{},
 			},
 		},
 	}
@@ -201,6 +208,19 @@ func TestUpdate(t *testing.T) {
 				mock.AnythingOfType("int"),
 				mock.AnythingOfType("models.SellerDTO"),
 			).Return(tt.wanted.seller, tt.callErr)
+
+			sv.On("Update", mock.AnythingOfType("int"), mock.MatchedBy(func(dto models.SellerDTO) bool {
+				if tt.callErr != nil {
+					return true
+				}
+
+				return !(dto.CID != tt.wanted.seller.CID ||
+					dto.CompanyName != tt.wanted.seller.CompanyName ||
+					dto.Address != tt.wanted.seller.Address ||
+					dto.Telephone != tt.wanted.seller.Telephone ||
+					dto.LocalityID != tt.wanted.seller.LocalityID)
+			}), mock.AnythingOfType("int")).Return(tt.wanted.seller, tt.callErr)
+
 			r.ServeHTTP(res, req)
 
 			// Assert


### PR DESCRIPTION
Motivação
Melhorar a robustez e a confiabilidade dos testes para os métodos de criação (create) e atualização (update) no controlador de sellers.

Solução proposta
O objetivo deste cartão é aprimorar os testes na camada de controle para os seguintes endpoints:
POST /api/v1/sellers
PATCH /api/v1/sellers/{id}

Cobertura de cenários
Verificar se o corpo da requisição enviado aos controllers é validado conforme a resposta esperada.
Garantir que a montagem do DTO dentro do controller seja verificada utilizando o método mock.MatchedBy da biblioteca Testify Mock.
Incluir cenários de teste para casos de sucesso e erro, assegurando que todos os fluxos de dados sejam contemplados.
Esta melhoria visa aumentar a qualidade do código e facilitar a detecção de falhas, assegurando que os métodos de controle estão funcionando conforme esperado.