### PR TITLE
refactors products create tests

### DIFF
--- a/internal/controllers/products/create_test.go
+++ b/internal/controllers/products/create_test.go
@@ -454,7 +454,23 @@ func TestProducts_Create(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/products", strings.NewReader(tt.productJSON))
 			res := httptest.NewRecorder()
 			//Act
-			sv.On("Create", mock.AnythingOfType("models.ProductDTO")).Return(product, tt.callErr)
+			sv.On("Create", mock.MatchedBy(func(dto models.ProductDTO) bool {
+				if tt.callErr != nil {
+					return true
+				}
+				return (dto.ProductCode == product.ProductCode &&
+					dto.Description == product.Description &&
+					dto.Height == product.Height &&
+					dto.Length == product.Length &&
+					dto.Width == product.Width &&
+					dto.NetWeight == product.NetWeight &&
+					dto.ExpirationRate == product.ExpirationRate &&
+					dto.FreezingRate == product.FreezingRate &&
+					dto.RecomFreezTemp == product.RecomFreezTemp &&
+					dto.ProductTypeID == product.ProductTypeID &&
+					dto.SellerID == product.SellerID)
+			})).Return(product, tt.callErr)
+
 			ctl.Create(res, req)
 
 			var decodedRes struct {


### PR DESCRIPTION
### Motivação
Conforme decidido em time, devemos fazer uma verificação para o DTO passado nas ações de create durante os testes, tornando a chamada do mock mais específica

### Solução proposta
Modifica arquivo de teste de método Create em controller de product para que a chamada do mock dependa de um DTO específico

### Como testar
`make test`
