### PR TITLE
adds factories packages with carries/product_records

### DIFF
--- a/internal/factories/carries.go
+++ b/internal/factories/carries.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/randstr"
 )
 
 type CarrieFactory struct {
@@ -18,10 +19,10 @@ func NewCarrieFactory(db *sql.DB) *CarrieFactory {
 
 func defaultCarrie() models.Carry {
 	return models.Carry{
-		CID:         RandAlphanumeric(8),
-		CompanyName: RandChars(8),
-		Address:     RandChars(8),
-		PhoneNumber: RandChars(11),
+		CID:         randstr.Alphanumeric(8),
+		CompanyName: randstr.Chars(8),
+		Address:     randstr.Chars(8),
+		PhoneNumber: randstr.Chars(11),
 		LocalityID:  1,
 	}
 }
@@ -99,13 +100,11 @@ func (f *CarrieFactory) checkLocalityExists(localityID int) (err error) {
 		return
 	}
 
-	if count == 0 {
-		err = fmt.Errorf("carrie with id %d does not exist", localityID)
+	if count > 0 {
+		return
 	}
 
-	if err != nil {
-		err = f.createLocality()
-	}
+	err = f.createLocality()
 
 	return
 }

--- a/internal/factories/carries.go
+++ b/internal/factories/carries.go
@@ -9,15 +9,15 @@ import (
 	"github.com/maxwelbm/alkemy-g6/pkg/randstr"
 )
 
-type CarrieFactory struct {
+type CarryFactory struct {
 	db *sql.DB
 }
 
-func NewCarrieFactory(db *sql.DB) *CarrieFactory {
-	return &CarrieFactory{db: db}
+func NewCarryFactory(db *sql.DB) *CarryFactory {
+	return &CarryFactory{db: db}
 }
 
-func defaultCarrie() models.Carry {
+func defaultCarry() models.Carry {
 	return models.Carry{
 		CID:         randstr.Alphanumeric(8),
 		CompanyName: randstr.Chars(8),
@@ -27,8 +27,8 @@ func defaultCarrie() models.Carry {
 	}
 }
 
-func (f *CarrieFactory) Create(carrie models.Carry) (record models.Carry, err error) {
-	populateCarrieParams(&carrie)
+func (f *CarryFactory) Create(carrie models.Carry) (record models.Carry, err error) {
+	populateCarryParams(&carrie)
 
 	if err = f.checkLocalityExists(carrie.LocalityID); err != nil {
 		return carrie, err
@@ -65,34 +65,34 @@ func (f *CarrieFactory) Create(carrie models.Carry) (record models.Carry, err er
 	return carrie, err
 }
 
-func populateCarrieParams(carrie *models.Carry) {
-	defaultCarrie := defaultCarrie()
+func populateCarryParams(carrie *models.Carry) {
+	defaultCarry := defaultCarry()
 	if carrie == nil {
-		carrie = &defaultCarrie
+		carrie = &defaultCarry
 	}
 
 	if carrie.CID == "" {
-		carrie.CID = defaultCarrie.CID
+		carrie.CID = defaultCarry.CID
 	}
 
 	if carrie.CompanyName == "" {
-		carrie.CompanyName = defaultCarrie.CompanyName
+		carrie.CompanyName = defaultCarry.CompanyName
 	}
 
 	if carrie.Address == "" {
-		carrie.Address = defaultCarrie.Address
+		carrie.Address = defaultCarry.Address
 	}
 
 	if carrie.PhoneNumber == "" {
-		carrie.PhoneNumber = defaultCarrie.PhoneNumber
+		carrie.PhoneNumber = defaultCarry.PhoneNumber
 	}
 
 	if carrie.LocalityID == 0 {
-		carrie.LocalityID = defaultCarrie.LocalityID
+		carrie.LocalityID = defaultCarry.LocalityID
 	}
 }
 
-func (f *CarrieFactory) checkLocalityExists(localityID int) (err error) {
+func (f *CarryFactory) checkLocalityExists(localityID int) (err error) {
 	var count int
 	err = f.db.QueryRow(`SELECT COUNT(*) FROM localities WHERE id = ?`, localityID).Scan(&count)
 
@@ -109,7 +109,7 @@ func (f *CarrieFactory) checkLocalityExists(localityID int) (err error) {
 	return
 }
 
-func (f *CarrieFactory) createLocality() (err error) {
+func (f *CarryFactory) createLocality() (err error) {
 	localityFactory := NewLocalityFactory(f.db)
 	_, err = localityFactory.Create(models.Locality{})
 

--- a/internal/factories/carries.go
+++ b/internal/factories/carries.go
@@ -1,0 +1,118 @@
+package factories
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+)
+
+type CarrieFactory struct {
+	db *sql.DB
+}
+
+func NewCarrieFactory(db *sql.DB) *CarrieFactory {
+	return &CarrieFactory{db: db}
+}
+
+func defaultCarrie() models.Carry {
+	return models.Carry{
+		CID:         RandAlphanumeric(8),
+		CompanyName: RandChars(8),
+		Address:     RandChars(8),
+		PhoneNumber: RandChars(11),
+		LocalityID:  1,
+	}
+}
+
+func (f *CarrieFactory) Create(carrie models.Carry) (record models.Carry, err error) {
+	populateCarrieParams(&carrie)
+
+	if err = f.checkLocalityExists(carrie.LocalityID); err != nil {
+		return carrie, err
+	}
+
+	query := `
+		INSERT INTO carries 
+			(
+			%s
+			cid,
+			company_name, 
+			address, 
+			phone_number, 
+			locality_id
+			) 
+		VALUES (%s?, ?, ?, ?, ?)
+	`
+
+	switch carrie.ID {
+	case 0:
+		query = fmt.Sprintf(query, "", "")
+	default:
+		query = fmt.Sprintf(query, "id,", strconv.Itoa(carrie.ID)+",")
+	}
+
+	_, err = f.db.Exec(query,
+		carrie.CID,
+		carrie.CompanyName,
+		carrie.Address,
+		carrie.PhoneNumber,
+		carrie.LocalityID,
+	)
+
+	return carrie, err
+}
+
+func populateCarrieParams(carrie *models.Carry) {
+	defaultCarrie := defaultCarrie()
+	if carrie == nil {
+		carrie = &defaultCarrie
+	}
+
+	if carrie.CID == "" {
+		carrie.CID = defaultCarrie.CID
+	}
+
+	if carrie.CompanyName == "" {
+		carrie.CompanyName = defaultCarrie.CompanyName
+	}
+
+	if carrie.Address == "" {
+		carrie.Address = defaultCarrie.Address
+	}
+
+	if carrie.PhoneNumber == "" {
+		carrie.PhoneNumber = defaultCarrie.PhoneNumber
+	}
+
+	if carrie.LocalityID == 0 {
+		carrie.LocalityID = defaultCarrie.LocalityID
+	}
+}
+
+func (f *CarrieFactory) checkLocalityExists(localityID int) (err error) {
+	var count int
+	err = f.db.QueryRow(`SELECT COUNT(*) FROM localities WHERE id = ?`, localityID).Scan(&count)
+
+	if err != nil {
+		return
+	}
+
+	if count == 0 {
+		err = fmt.Errorf("carrie with id %d does not exist", localityID)
+	}
+
+	if err != nil {
+		err = f.createLocality()
+	}
+
+	return
+}
+
+func (f *CarrieFactory) createLocality() (err error) {
+	localityFactory := NewLocalityFactory(f.db)
+	_, err = localityFactory.Create(models.Locality{})
+
+	return
+}

--- a/internal/factories/localities.go
+++ b/internal/factories/localities.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/randstr"
 )
 
 type LocalityFactory struct {
@@ -18,9 +19,9 @@ func NewLocalityFactory(db *sql.DB) *LocalityFactory {
 
 func defaultLocality() models.Locality {
 	return models.Locality{
-		LocalityName: RandChars(8),
-		ProvinceName: RandChars(8),
-		CountryName:  RandChars(8),
+		LocalityName: randstr.Chars(8),
+		ProvinceName: randstr.Chars(8),
+		CountryName:  randstr.Chars(8),
 	}
 }
 

--- a/internal/factories/product_records.go
+++ b/internal/factories/product_records.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/randstr"
 )
 
 type ProductRecodsFactory struct {
@@ -18,7 +19,7 @@ func NewProductRecodsFactory(db *sql.DB) *ProductRecodsFactory {
 
 func defaultProductRecords() models.ProductRecord {
 	return models.ProductRecord{
-		LastUpdateDate: RandChars(8),
+		LastUpdateDate: randstr.Chars(8),
 		PurchasePrice:  10.0,
 		SalePrice:      10.0,
 		ProductID:      1,
@@ -85,19 +86,17 @@ func populateProductRecordsParams(productRecord *models.ProductRecord) {
 
 func (f *ProductRecodsFactory) checkProductExists(productID int) (err error) {
 	var count int
-	err = f.db.QueryRow(`SELECT COUNT(*) FROM product WHERE id = ?`, productID).Scan(&count)
+	err = f.db.QueryRow(`SELECT COUNT(*) FROM products WHERE id = ?`, productID).Scan(&count)
 
 	if err != nil {
 		return
 	}
 
-	if count == 0 {
-		err = fmt.Errorf("product with id %d does not exist", productID)
+	if count > 0 {
+		return
 	}
 
-	if err != nil {
-		err = f.createProduct()
-	}
+	err = f.createProduct()
 
 	return
 }

--- a/internal/factories/product_records.go
+++ b/internal/factories/product_records.go
@@ -1,0 +1,110 @@
+package factories
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+)
+
+type ProductRecodsFactory struct {
+	db *sql.DB
+}
+
+func NewProductRecodsFactory(db *sql.DB) *ProductRecodsFactory {
+	return &ProductRecodsFactory{db: db}
+}
+
+func defaultProductRecords() models.ProductRecord {
+	return models.ProductRecord{
+		LastUpdateDate: RandChars(8),
+		PurchasePrice:  10.0,
+		SalePrice:      10.0,
+		ProductID:      1,
+	}
+}
+
+func (f *ProductRecodsFactory) Create(productRecord models.ProductRecord) (record models.ProductRecord, err error) {
+	populateProductRecordsParams(&productRecord)
+
+	if err = f.checkProductExists(productRecord.ProductID); err != nil {
+		return productRecord, err
+	}
+
+	query := `
+		INSERT INTO productRecords 
+			(
+			%s
+			last_update_date,
+			purchase_price, 
+			sale_price, 
+			product_id
+			) 
+		VALUES (%s?, ?, ?, ?)
+	`
+
+	switch productRecord.ID {
+	case 0:
+		query = fmt.Sprintf(query, "", "")
+	default:
+		query = fmt.Sprintf(query, "id,", strconv.Itoa(productRecord.ID)+",")
+	}
+
+	_, err = f.db.Exec(query,
+		productRecord.LastUpdateDate,
+		productRecord.PurchasePrice,
+		productRecord.SalePrice,
+		productRecord.ProductID)
+
+	return productRecord, err
+}
+
+func populateProductRecordsParams(productRecord *models.ProductRecord) {
+	defaultProductRecords := defaultProductRecords()
+	if productRecord == nil {
+		productRecord = &defaultProductRecords
+	}
+
+	if productRecord.LastUpdateDate == "" {
+		productRecord.LastUpdateDate = defaultProductRecords.LastUpdateDate
+	}
+
+	if productRecord.PurchasePrice == 0.0 {
+		productRecord.PurchasePrice = defaultProductRecords.PurchasePrice
+	}
+
+	if productRecord.SalePrice == 0.0 {
+		productRecord.SalePrice = defaultProductRecords.SalePrice
+	}
+
+	if productRecord.ProductID == 0 {
+		productRecord.ProductID = defaultProductRecords.ProductID
+	}
+}
+
+func (f *ProductRecodsFactory) checkProductExists(productID int) (err error) {
+	var count int
+	err = f.db.QueryRow(`SELECT COUNT(*) FROM product WHERE id = ?`, productID).Scan(&count)
+
+	if err != nil {
+		return
+	}
+
+	if count == 0 {
+		err = fmt.Errorf("product with id %d does not exist", productID)
+	}
+
+	if err != nil {
+		err = f.createProduct()
+	}
+
+	return
+}
+
+func (f *ProductRecodsFactory) createProduct() (err error) {
+	productFactory := NewProductFactory(f.db)
+	_, err = productFactory.Create(models.Product{})
+
+	return
+}

--- a/internal/factories/products.go
+++ b/internal/factories/products.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/randstr"
 )
 
 type ProductFactory struct {
@@ -18,8 +19,8 @@ func NewProductFactory(db *sql.DB) *ProductFactory {
 
 func defaultProduct() models.Product {
 	return models.Product{
-		ProductCode:    RandAlphanumeric(8),
-		Description:    RandChars(16),
+		ProductCode:    randstr.Alphanumeric(8),
+		Description:    randstr.Chars(16),
 		Height:         10,
 		Length:         10,
 		Width:          10,
@@ -157,13 +158,11 @@ func (f *ProductFactory) checkSellerExists(sellerID int) (err error) {
 		return
 	}
 
-	if count == 0 {
-		err = fmt.Errorf("seller with id %d does not exist", sellerID)
+	if count > 0 {
+		return
 	}
 
-	if err != nil {
-		err = f.createSeller()
-	}
+	err = f.createSeller()
 
 	return
 }

--- a/internal/factories/sellers.go
+++ b/internal/factories/sellers.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/randstr"
 )
 
 type SellerFactory struct {
@@ -18,10 +19,10 @@ func NewSellerFactory(db *sql.DB) *SellerFactory {
 
 func defaultSeller() models.Seller {
 	return models.Seller{
-		CID:         RandAlphanumeric(8),
-		CompanyName: RandChars(8),
-		Address:     RandChars(8),
-		Telephone:   RandChars(11),
+		CID:         randstr.Alphanumeric(8),
+		CompanyName: randstr.Chars(8),
+		Address:     randstr.Chars(8),
+		Telephone:   randstr.Chars(11),
 		LocalityID:  1,
 	}
 }
@@ -99,13 +100,11 @@ func (f *SellerFactory) checkLocalityExists(localityID int) (err error) {
 		return
 	}
 
-	if count == 0 {
-		err = fmt.Errorf("seller with id %d does not exist", localityID)
+	if count > 0 {
+		return
 	}
 
-	if err != nil {
-		err = f.createLocality()
-	}
+	err = f.createLocality()
 
 	return
 }

--- a/pkg/randstr/randstr.go
+++ b/pkg/randstr/randstr.go
@@ -1,16 +1,15 @@
-package factories
+package randstr
 
 import (
+	"math/rand"
 	"time"
-
-	"golang.org/x/exp/rand"
 )
 
 var alphabet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 var alphanumeric = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
-func RandChars(n int) string {
-	rand.Seed(uint64(time.Now().UnixNano()))
+func Chars(n int) string {
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	b := make([]rune, n)
 	for i := range b {
@@ -20,8 +19,8 @@ func RandChars(n int) string {
 	return string(b)
 }
 
-func RandAlphanumeric(n int) string {
-	rand.Seed(uint64(time.Now().UnixNano()))
+func Alphanumeric(n int) string {
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	b := make([]rune, n)
 	for i := range b {


### PR DESCRIPTION
Motivação
Criação de factories de carries e product_records

Solução proposta
Foram adicionados factories para os models carries e product_records
Em caso de dependencia entre models, o código se encarrega de inserir no banco de dados os registros para satisfazer dependencias de foreign keys