### PR TITLE
Implement tests for warehouse crud

### DIFF
--- a/internal/factories/warehouses.go
+++ b/internal/factories/warehouses.go
@@ -46,7 +46,7 @@ func (f *WarehouseFactory) Create(warehouse models.Warehouse) (record models.War
 			minimum_capacity,
 			minimum_temperature
 			) 
-		VALUES (%s?, ?, ?, ?, ?, ?)
+		VALUES (%s?, ?, ?, ?, ?)
 	`
 
 	switch warehouse.ID {

--- a/internal/repository/warehouses/create_test.go
+++ b/internal/repository/warehouses/create_test.go
@@ -1,0 +1,90 @@
+package warehousesrp
+
+import (
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/maxwelbm/alkemy-g6/internal/factories"
+	models "github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/mysqlerr"
+	"github.com/maxwelbm/alkemy-g6/pkg/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreate(t *testing.T) {
+	db, truncate, teardown := testdb.NewConn(t)
+	defer teardown()
+	factory := factories.NewWarehouseFactory(db)
+	fixture := factory.Build(models.Warehouse{ID: 1})
+
+	type arg struct {
+		dto models.WarehouseDTO
+	}
+	type want struct {
+		warehouse models.Warehouse
+		err       error
+	}
+	tests := []struct {
+		name  string
+		setup func()
+		arg
+		want
+	}{
+		{
+			name: "When successfully creating a new Warehouse",
+			arg: arg{
+				dto: models.WarehouseDTO{
+					Address:            &fixture.Address,
+					Telephone:          &fixture.Telephone,
+					WarehouseCode:      &fixture.WarehouseCode,
+					MinimumCapacity:    &fixture.MinimumCapacity,
+					MinimumTemperature: &fixture.MinimumTemperature,
+				},
+			},
+			want: want{
+				warehouse: fixture,
+				err:       nil,
+			},
+		},
+		{
+			name: "Error - When creating a duplicated Warehouse",
+			setup: func() {
+				_, err := factory.Create(fixture)
+				require.NoError(t, err)
+			},
+			arg: arg{
+				dto: models.WarehouseDTO{
+					Address:            &fixture.Address,
+					Telephone:          &fixture.Telephone,
+					WarehouseCode:      &fixture.WarehouseCode,
+					MinimumCapacity:    &fixture.MinimumCapacity,
+					MinimumTemperature: &fixture.MinimumTemperature,
+				},
+			},
+			want: want{
+				err: &mysql.MySQLError{Number: mysqlerr.CodeDuplicateEntry},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			t.Cleanup(truncate)
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			// Arrange
+			rp := NewWarehouseRepository(db)
+			// Act
+			got, err := rp.Create(tt.dto)
+
+			// Assert
+			if tt.err != nil {
+				require.ErrorIs(t, tt.err, err)
+			}
+			require.Equal(t, tt.want.warehouse, got)
+		})
+	}
+}

--- a/internal/repository/warehouses/delete_test.go
+++ b/internal/repository/warehouses/delete_test.go
@@ -1,0 +1,72 @@
+package warehousesrp
+
+import (
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/factories"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelete(t *testing.T) {
+	db, truncate, teardown := testdb.NewConn(t)
+	defer teardown()
+	factory := factories.NewWarehouseFactory(db)
+
+	type arg struct {
+		id int
+	}
+	type want struct {
+		err error
+	}
+	tests := []struct {
+		name  string
+		setup func()
+		arg
+		want
+	}{
+		{
+			name: "When successfully deleting a new warehouse",
+			setup: func() {
+				_, err := factory.Create(models.Warehouse{ID: 1})
+				require.NoError(t, err)
+			},
+			arg: arg{
+				id: 1,
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		{
+			name: "Error - When trying to delete a warehouse that does not exist",
+			arg: arg{
+				id: 1,
+			},
+			want: want{
+				err: models.ErrWareHouseNotFound,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			t.Cleanup(truncate)
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			// Arrange
+			rp := NewWarehouseRepository(db)
+			// Act
+			err := rp.Delete(tt.id)
+
+			// Assert
+			if tt.err != nil {
+				require.ErrorIs(t, tt.err, err)
+			}
+		})
+	}
+}

--- a/internal/repository/warehouses/get_all_test.go
+++ b/internal/repository/warehouses/get_all_test.go
@@ -1,0 +1,71 @@
+package warehousesrp
+
+import (
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/factories"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAll(t *testing.T) {
+	db, truncate, teardown := testdb.NewConn(t)
+	defer teardown()
+
+	factory := factories.NewWarehouseFactory(db)
+	wh1 := factory.Build(models.Warehouse{ID: 1})
+	wh2 := factory.Build(models.Warehouse{ID: 2})
+	wh3 := factory.Build(models.Warehouse{ID: 3})
+
+	type want struct {
+		warehouses []models.Warehouse
+	}
+
+	tests := []struct {
+		name  string
+		setup func()
+		want
+	}{
+		{
+			name: "When warehouses are registered",
+			setup: func() {
+				_, err := factory.Create(wh1)
+				require.NoError(t, err)
+				_, err = factory.Create(wh2)
+				require.NoError(t, err)
+				_, err = factory.Create(wh3)
+				require.NoError(t, err)
+			},
+			want: want{
+				warehouses: []models.Warehouse{wh1, wh2, wh3},
+			},
+		},
+		{
+			name: "When no warehouses are registered",
+			want: want{
+				warehouses: []models.Warehouse(nil),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			t.Cleanup(truncate)
+
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			// Arrange
+			rp := NewWarehouseRepository(db)
+			// Act
+			got, err := rp.GetAll()
+
+			// Assert
+			require.NoError(t, err)
+			require.Equal(t, tt.want.warehouses, got)
+		})
+	}
+}

--- a/internal/repository/warehouses/get_by_id.go
+++ b/internal/repository/warehouses/get_by_id.go
@@ -14,7 +14,7 @@ func (r *WarehouseRepository) GetByID(id int) (w models.Warehouse, err error) {
 
 	if err = rows.Scan(&w.ID, &w.Address, &w.Telephone, &w.WarehouseCode, &w.MinimumCapacity, &w.MinimumTemperature); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			err = ErrWarehouseRepositoryNotFound
+			err = models.ErrWareHouseNotFound
 			return
 		}
 	}

--- a/internal/repository/warehouses/get_by_id_test.go
+++ b/internal/repository/warehouses/get_by_id_test.go
@@ -1,0 +1,73 @@
+package warehousesrp
+
+import (
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/factories"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetByID(t *testing.T) {
+	db, truncate, teardown := testdb.NewConn(t)
+	defer teardown()
+	factory := factories.NewWarehouseFactory(db)
+	wh := factory.Build(models.Warehouse{ID: 1})
+
+	type arg struct {
+		id int
+	}
+	type want struct {
+		warehouses models.Warehouse
+		err        error
+	}
+	tests := []struct {
+		name  string
+		setup func()
+		arg
+		want
+	}{
+		{
+			name: "When the warehouse is found",
+			setup: func() {
+				_, err := factory.Create(wh)
+				require.NoError(t, err)
+			},
+			arg: arg{
+				id: 1,
+			},
+			want: want{
+				warehouses: wh,
+			},
+		},
+		{
+			name: "When the warehouse is not found",
+			arg: arg{
+				id: 1,
+			},
+			want: want{
+				err: models.ErrWareHouseNotFound,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			t.Cleanup(truncate)
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			// Arrange
+			rp := NewWarehouseRepository(db)
+			// Act
+			got, err := rp.GetByID(tt.id)
+
+			// Assert
+			require.ErrorIs(t, err, tt.want.err)
+			require.Equal(t, tt.want.warehouses, got)
+		})
+	}
+}

--- a/internal/repository/warehouses/update.go
+++ b/internal/repository/warehouses/update.go
@@ -1,6 +1,9 @@
 package warehousesrp
 
 import (
+	"database/sql"
+	"errors"
+
 	"github.com/maxwelbm/alkemy-g6/internal/models"
 )
 
@@ -17,8 +20,6 @@ func (r *WarehouseRepository) Update(id int, warehouse models.WarehouseDTO) (w m
 			err = models.ErrWareHouseCodeExist
 			return w, err
 		}
-
-		w.WarehouseCode = *warehouse.WarehouseCode
 	}
 
 	//COALESCE: used to retain the current value of the field if the new value is null or not applicable
@@ -37,6 +38,11 @@ func (r *WarehouseRepository) Update(id int, warehouse models.WarehouseDTO) (w m
 
 	query = "SELECT `id`,`address`, `telephone`, `warehouse_code`, `minimum_capacity`, `minimum_temperature` FROM warehouses WHERE `id`=?"
 	if err = r.db.QueryRow(query, id).Scan(&w.ID, &w.Address, &w.Telephone, &w.WarehouseCode, &w.MinimumCapacity, &w.MinimumTemperature); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			err = models.ErrWareHouseNotFound
+			return w, err
+		}
+		
 		return w, err
 	}
 

--- a/internal/repository/warehouses/update_test.go
+++ b/internal/repository/warehouses/update_test.go
@@ -1,0 +1,106 @@
+package warehousesrp
+
+import (
+	"testing"
+
+	"github.com/maxwelbm/alkemy-g6/internal/factories"
+	"github.com/maxwelbm/alkemy-g6/internal/models"
+	"github.com/maxwelbm/alkemy-g6/pkg/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdate(t *testing.T) {
+	db, truncate, teardown := testdb.NewConn(t)
+	defer teardown()
+	factory := factories.NewWarehouseFactory(db)
+	wh := factory.Build(models.Warehouse{ID: 1})
+	newCode := "NEWCODE"
+
+	type arg struct {
+		id  int
+		dto models.WarehouseDTO
+	}
+	type want struct {
+		warehouse models.Warehouse
+		err       error
+	}
+	tests := []struct {
+		name  string
+		setup func()
+		arg
+		want
+	}{
+		{
+			name: "When successfully updating a warehouse",
+			setup: func() {
+				_, err := factory.Create(wh)
+				require.NoError(t, err)
+			},
+			arg: arg{
+				id: 1,
+				dto: models.WarehouseDTO{
+					WarehouseCode: &newCode,
+				},
+			},
+			want: want{
+				warehouse: func() models.Warehouse {
+					cpy := wh
+					cpy.WarehouseCode = newCode
+					return cpy
+				}(),
+				err: nil,
+			},
+		},
+		{
+			name: "Error - When the warehouse is not found",
+			arg: arg{
+				id: 1,
+				dto: models.WarehouseDTO{
+					WarehouseCode: &newCode,
+				},
+			},
+			want: want{
+				err: models.ErrWareHouseNotFound,
+			},
+		},
+		{
+			name: "Error - When attempting to update a Warehouse with a duplicate WarehouseCode",
+			setup: func() {
+				_, err := factory.Create(wh)
+				require.NoError(t, err)
+				_, err = factory.Create(factory.Build(models.Warehouse{ID: 2}))
+				require.NoError(t, err)
+			},
+			arg: arg{
+				id: 2,
+				dto: models.WarehouseDTO{
+					WarehouseCode: &wh.WarehouseCode,
+				},
+			},
+			want: want{
+				err: models.ErrWareHouseCodeExist,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			t.Cleanup(truncate)
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			// Arrange
+			rp := NewWarehouseRepository(db)
+			// Act
+			got, err := rp.Update(tt.id, tt.dto)
+
+			// Assert
+			if tt.err != nil {
+				require.ErrorIs(t, tt.err, err)
+			}
+			require.Equal(t, tt.want.warehouse, got)
+		})
+	}
+}

--- a/internal/repository/warehouses/warehouses_default.go
+++ b/internal/repository/warehouses/warehouses_default.go
@@ -2,11 +2,6 @@ package warehousesrp
 
 import (
 	"database/sql"
-	"errors"
-)
-
-var (
-	ErrWarehouseRepositoryNotFound = errors.New("warehouse not found")
 )
 
 type WarehouseRepository struct {


### PR DESCRIPTION
## Motivação
Testes de integração para garantir o correto funcionamento do repositório de Warehouses, aumentando a cobertura e confiabilidade do código.

## Solução proposta
Implementação de testes de integração para os métodos do repositório de Warehouses

Cobertura dos seguintes cenários:
**Create**: criação bem-sucedida e tratamento de duplicidade do WarehouseCode
**GetByID**: busca por ID existente e inexistente
**Delete**: exclusão bem-sucedida e tentativa de exclusão de warehouse inexistente
**GetAll**: listagem de múltiplas warehouses e retorno de lista vazia quando não há registros
**Update**: atualização bem-sucedida, tratamento de warehouse inexistente, e validação de duplicidade do WarehouseCode

## Como testar
```make test```